### PR TITLE
fix(Card): use snippet URL if card is a snippet

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -415,7 +415,7 @@ export default class Card extends React.Component<CardProps, {
               title={this.props.type === "snippet" ? this.props.item.title : this.props.item.manifest?.name}
               className="main-cardHeader-link"
               dir="auto"
-              href={this.props.type === "snippet"
+              href={this.props.type !== "snippet"
                 ? `https://github.com/${this.props.item.user}/${this.props.item.repo}`
                 : "https://github.com/spicetify/spicetify-marketplace/blob/main/resources/snippets.json"
               }

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -415,7 +415,10 @@ export default class Card extends React.Component<CardProps, {
               title={this.props.type === "snippet" ? this.props.item.title : this.props.item.manifest?.name}
               className="main-cardHeader-link"
               dir="auto"
-              href={`https://github.com/${this.props.item.user}/${this.props.item.repo}`}
+              href={this.props.type === "snippet"
+                ? `https://github.com/${this.props.item.user}/${this.props.item.repo}`
+                : "https://github.com/spicetify/spicetify-marketplace/blob/main/resources/snippets.json"
+              }
               target="_blank"
               rel="noopener noreferrer"
               onClick={(e) => e.stopPropagation()}

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { CardItem, CardType, Config, SchemeIni, Snippet, VisualConfig } from "../../types/marketplace-types";
 
-import { LOCALSTORAGE_KEYS, CUSTOM_APP_PATH } from "../../constants";
+import { LOCALSTORAGE_KEYS, CUSTOM_APP_PATH, SNIPPETS_PAGE_URL } from "../../constants";
 import {
   getLocalStorageDataFromKey,
   parseIni,
@@ -417,7 +417,7 @@ export default class Card extends React.Component<CardProps, {
               dir="auto"
               href={this.props.type !== "snippet"
                 ? `https://github.com/${this.props.item.user}/${this.props.item.repo}`
-                : "https://github.com/spicetify/spicetify-marketplace/blob/main/resources/snippets.json"
+                : SNIPPETS_PAGE_URL
               }
               target="_blank"
               rel="noopener noreferrer"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -32,4 +32,6 @@ export const MAX_TAGS = 4;
 
 export const SNIPPETS_URL = "https://raw.githubusercontent.com/spicetify/spicetify-marketplace/main/resources/snippets.json";
 
+export const SNIPPETS_PAGE_URL = "https://github.com/spicetify/spicetify-marketplace/blob/main/resources/snippets.json";
+
 export const BLACKLIST_URL = "https://raw.githubusercontent.com/spicetify/spicetify-marketplace/main/resources/blacklist.json";


### PR DESCRIPTION
Fix `href` for snippet Cards as they don't have their own repos and authors field and would return `undefined`