### PR TITLE
fix(TabRow): Marketplace crashing on moving tabs

### DIFF
--- a/src/components/Modals/Settings/TabRow.tsx
+++ b/src/components/Modals/Settings/TabRow.tsx
@@ -58,12 +58,12 @@ const TabRow = (props: {
     <div className="setting-row">
       <label htmlFor={toggleId} className='col description'>{props.name}</label>
       <div className="col action">
-        <button title="Move up" className="arrow-btn" disabled={index === 0} style={ index === 0 ? { cursor: "not-allowed" } : undefined } onClick={() => moveTab(index, -1)}>
+        <button title="Move up" className="arrow-btn" disabled={index === 0} onClick={() => moveTab(index, -1)}>
           <svg height="16" width="16" viewBox="0 0 16 16" fill="currentColor"
             dangerouslySetInnerHTML={{ __html: String(Spicetify.SVGIcons["chart-up"]) }}>
           </svg>
         </button>
-        <button title="Move down" className="arrow-btn" disabled={index === 3} style={ index === 3 ? { cursor: "not-allowed" } : undefined } onClick={() => moveTab(index, 1)}>
+        <button title="Move down" className="arrow-btn" disabled={index === 3} onClick={() => moveTab(index, 1)}>
           <svg height="16" width="16" viewBox="0 0 16 16" fill="currentColor"
             dangerouslySetInnerHTML={{ __html: String(Spicetify.SVGIcons["chart-down"]) }}>
           </svg>

--- a/src/components/Modals/Settings/TabRow.tsx
+++ b/src/components/Modals/Settings/TabRow.tsx
@@ -58,12 +58,12 @@ const TabRow = (props: {
     <div className="setting-row">
       <label htmlFor={toggleId} className='col description'>{props.name}</label>
       <div className="col action">
-        <button title="Move up" className="arrow-btn" disabled={index === 0} onClick={() => moveTab(index, -1)}>
+        <button title="Move up" className="arrow-btn" disabled={index === 0} style={ index === 0 ? { cursor: "not-allowed" } : undefined } onClick={() => moveTab(index, -1)}>
           <svg height="16" width="16" viewBox="0 0 16 16" fill="currentColor"
             dangerouslySetInnerHTML={{ __html: String(Spicetify.SVGIcons["chart-up"]) }}>
           </svg>
         </button>
-        <button title="Move down" className="arrow-btn" disabled={index === 3} onClick={() => moveTab(index, 1)}>
+        <button title="Move down" className="arrow-btn" disabled={index === 3} style={ index === 3 ? { cursor: "not-allowed" } : undefined } onClick={() => moveTab(index, 1)}>
           <svg height="16" width="16" viewBox="0 0 16 16" fill="currentColor"
             dangerouslySetInnerHTML={{ __html: String(Spicetify.SVGIcons["chart-down"]) }}>
           </svg>

--- a/src/components/Modals/Settings/TabRow.tsx
+++ b/src/components/Modals/Settings/TabRow.tsx
@@ -58,12 +58,12 @@ const TabRow = (props: {
     <div className="setting-row">
       <label htmlFor={toggleId} className='col description'>{props.name}</label>
       <div className="col action">
-        <button title="Move up" className="arrow-btn" onClick={() => moveTab(index, -1)}>
+        <button title="Move up" className="arrow-btn" disabled={index === 0} onClick={() => moveTab(index, -1)}>
           <svg height="16" width="16" viewBox="0 0 16 16" fill="currentColor"
             dangerouslySetInnerHTML={{ __html: String(Spicetify.SVGIcons["chart-up"]) }}>
           </svg>
         </button>
-        <button title="Move down" className="arrow-btn" onClick={() => moveTab(index, 1)}>
+        <button title="Move down" className="arrow-btn" disabled={index === 3} onClick={() => moveTab(index, 1)}>
           <svg height="16" width="16" viewBox="0 0 16 16" fill="currentColor"
             dangerouslySetInnerHTML={{ __html: String(Spicetify.SVGIcons["chart-down"]) }}>
           </svg>

--- a/src/components/Modals/Settings/TabRow.tsx
+++ b/src/components/Modals/Settings/TabRow.tsx
@@ -63,7 +63,7 @@ const TabRow = (props: {
             dangerouslySetInnerHTML={{ __html: String(Spicetify.SVGIcons["chart-up"]) }}>
           </svg>
         </button>
-        <button title="Move down" className="arrow-btn" disabled={index === 3} onClick={() => moveTab(index, 1)}>
+        <button title="Move down" className="arrow-btn" disabled={index === props.modalConfig.tabs.length - 1} onClick={() => moveTab(index, 1)}>
           <svg height="16" width="16" viewBox="0 0 16 16" fill="currentColor"
             dangerouslySetInnerHTML={{ __html: String(Spicetify.SVGIcons["chart-down"]) }}>
           </svg>

--- a/src/styles/components/_settings.scss
+++ b/src/styles/components/_settings.scss
@@ -40,6 +40,7 @@ button.arrow-btn {
   &.disabled,
   &[disabled] {
     color: rgba(var(--spice-rgb-text), .3);
+    cursor: not-allowed;
   }
 }
 


### PR DESCRIPTION
Fixed an issue where Marketplace would crash on moving tabs to non-existent index

<details>
<summary>Details</summary>

- Before:
![Spotify_cGbxTCwC9i](https://user-images.githubusercontent.com/77577746/173219594-77ebc227-8c6d-4e26-be59-8891f5ce469a.gif)

- After:
![Spotify_duNqPErbVF](https://user-images.githubusercontent.com/77577746/173219707-25f1a0f4-6bc1-4d34-b4c7-8ec859f462e4.gif)

</details>

