### PR TITLE
fix(Card): remove duplicate tags from appearing

### DIFF
--- a/src/components/Card/TagsDiv.tsx
+++ b/src/components/Card/TagsDiv.tsx
@@ -9,10 +9,14 @@ const TagsDiv = (props: {
   const [expanded, setExpanded] = React.useState(false);
 
   const generateTags = (tags: string[]) => {
-    // Remove duplicate tags from appearing
-    const uniqueTags = tags.filter((item, pos, self) => self.indexOf(item) === pos);
+    // Stop duplicate tags from appearing
+    const uniqueTags = tags.filter((item, pos, arr) => arr.indexOf(item) === pos);
 
-    return uniqueTags.reduce<DetailedReactHTMLElement<{ className: string; draggable: false; "data-tag": string; }, HTMLElement>[]>((accum, tag) => {
+    return uniqueTags.reduce<DetailedReactHTMLElement<{
+      className: string;
+      draggable: false;
+      "data-tag": string;
+    }, HTMLElement>[]>((accum, tag) => {
       // Render tags if enabled. Always render external JS tag
       if (props.showTags || tag === "external JS") {
         accum.push(
@@ -31,8 +35,6 @@ const TagsDiv = (props: {
   const extraTags = props.tags.slice(MAX_TAGS);
 
   // Render the tags list and add expand button if there are more tags
-  // TODO: JSX needs to return a single element,
-  // so may need to adjust the css that had it returning an array before...
   return (
     <div className="marketplace-card__tags-container">
       <ul className="marketplace-card__tags">

--- a/src/components/Card/TagsDiv.tsx
+++ b/src/components/Card/TagsDiv.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { DetailedReactHTMLElement } from "react";
 
 import { MAX_TAGS } from "../../constants";
 
@@ -8,8 +8,11 @@ const TagsDiv = (props: {
 }) => {
   const [expanded, setExpanded] = React.useState(false);
 
-  const generateTags = (tags) => {
-    return tags.reduce((accum, tag) => {
+  const generateTags = (tags: string[]) => {
+    // Remove duplicate tags from appearing
+    const uniqueTags = tags.filter((item, pos, self) => self.indexOf(item) === pos);
+
+    return uniqueTags.reduce<DetailedReactHTMLElement<{ className: string; draggable: false; "data-tag": string; }, HTMLElement>[]>((accum, tag) => {
       // Render tags if enabled. Always render external JS tag
       if (props.showTags || tag === "external JS") {
         accum.push(


### PR DESCRIPTION
Fix an issue where the Card tags could duplicate when rendered in `Installed` tab

![image](https://user-images.githubusercontent.com/77577746/174423078-e238b683-9a3d-4655-b015-9e8b7c8dfbe6.png)
![image](https://user-images.githubusercontent.com/77577746/174423081-2208ef86-dabd-4062-813e-b75061738ae4.png)

Also declared types for ease of maintenance.