### PR TITLE
fix(ci): don't copy nonexistent docs folder

### DIFF
--- a/packages/marketplace/package.json
+++ b/packages/marketplace/package.json
@@ -13,7 +13,7 @@
 		"build": "spicetify-creator",
 		"build:local": "spicetify-creator --out=dist --minify",
 		"build:prod": "yarn build:local && yarn copy:docs",
-		"copy:docs": "copyfiles README.md docs/* dist/",
+		"copy:docs": "copyfiles README.md dist/",
 		"lint": "eslint --fix src",
 		"lint:ci": "eslint src",
 		"type-check": "tsc --noEmit",


### PR DESCRIPTION
Points to correct path for `copy:docs`