### PR TITLE
feat(install): use placeholder theme

### DIFF
--- a/resources/color.ini
+++ b/resources/color.ini
@@ -1,0 +1,16 @@
+[Marketplace]
+text               = FFFFFF
+subtext            = b3b3b3
+main               = 121212
+sidebar            = 000000
+player             = 212121
+card               = 282828
+shadow             = 000000
+selected-row       = ffffff
+button             = 1877f2
+button-active      = 1ed760
+button-disabled    = 535353
+tab-active         = 333333
+notification       = 2e77d0
+notification-error = cd1a2b
+misc               = 7f7f7f

--- a/resources/install.ps1
+++ b/resources/install.ps1
@@ -36,8 +36,13 @@ spicetify config replace_colors 1
 
 $currentTheme = spicetify config current_theme | Out-String
 if ($currentTheme.Length -lt 3) {
-  Write-Host -ForegroundColor Red "No theme is found, applying default theme..."
-  spicetify config current_theme SpicetifyDefault
+  Write-Host -ForegroundColor Red "No theme is found, applying placeholder theme..."
+  if (-not (Test-Path "$spicePath\Themes\Marketplace")) {
+    Write-Host "Making placeholder theme folder..." -ForegroundColor "Cyan"
+    New-Item -Path "$spicePath\Themes\Marketplace" -ItemType Directory | Out-Null
+  }
+  Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/spicetify/spicetify-marketplace/main/resources/color.ini" -OutFile "$spicePath\Themes\Marketplace"
+  spicetify config current_theme Marketplace
 }
 
 spicetify backup

--- a/resources/install.sh
+++ b/resources/install.sh
@@ -5,6 +5,7 @@
 set -e
 
     download_uri="https://github.com/spicetify/spicetify-marketplace/archive/refs/heads/dist.zip"
+    default_color_uri="https://raw.githubusercontent.com/spicetify/spicetify-marketplace/main/resources/color.ini"
 
 SPICETIFY_CONFIG_DIR="${SPICETIFY_CONFIG:-$HOME/.config/spicetify}"
 INSTALL_DIR="$SPICETIFY_CONFIG_DIR/CustomApps"
@@ -39,7 +40,15 @@ spicetify config inject_css 1
 spicetify config replace_colors 1
 
 current_theme=$(spicetify config current_theme)
-if [ ${#current_theme} -le 3 ]; then spicetify config current_theme SpicetifyDefault; fi
+if [ ${#current_theme} -le 3 ]; then
+    echo "No theme selected, using placeholder theme"
+    if [ ! -d "$SPICETIFY_CONFIG_DIR/Themes/Marketplace" ]; then
+        echo "MAKING FOLDER  $SPICETIFY_CONFIG_DIR/Themes/Marketplace";
+        mkdir -p "$SPICETIFY_CONFIG_DIR/Themes/Marketplace"
+    fi
+    curl --fail --location --progress-bar --output "$SPICETIFY_CONFIG_DIR/Themes/Marketplace/color.ini" "$default_color_uri"
+    spicetify config current_theme Marketplace;
+fi
 
 if spicetify config custom_apps marketplace ; then
     echo "Added to config!"


### PR DESCRIPTION
Uses a placeholder theme instead of `SpicetifyDefault` as to not break theme installation
- `color.ini` values are default Spotify colors