### PR TITLE
fix(app): null check for `ReadmePage` & styling

### DIFF
--- a/packages/marketplace/src/app.tsx
+++ b/packages/marketplace/src/app.tsx
@@ -104,10 +104,10 @@ class App extends React.Component<null, {count: number, CONFIG: Config}> {
   };
 
   render() {
-    const { location, length } = Spicetify.Platform.History;
+    const { location } = Spicetify.Platform.History;
     // If page state set to display readme, render it
     // (This location state data comes from Card.openReadme())
-    if (location.pathname === `${CUSTOM_APP_PATH}/readme` && length > 1) {
+    if (location.pathname === `${CUSTOM_APP_PATH}/readme` && location.state.data) {
       return <ReadmePage title='Spicetify Marketplace - Readme' data={location.state.data} />;
     } // Otherwise, render the main Grid
     else {

--- a/packages/marketplace/src/styles/components/_grid.scss
+++ b/packages/marketplace/src/styles/components/_grid.scss
@@ -124,7 +124,8 @@
   flex-grow: 1;
 }
 .searchbar-bar {
-  border: unset;
+  border-style: solid;
+  border-color: var(--spice-sidebar);
   background-color: var(--spice-sidebar) !important;
   border-radius: constants.$btn-radius;
   padding: 10px 12px;

--- a/packages/marketplace/src/styles/components/_grid.scss
+++ b/packages/marketplace/src/styles/components/_grid.scss
@@ -19,7 +19,7 @@
 
 .marketplace-header__right, .marketplace-header__left {
   display: flex;
-  & > * {
+  & > div {
     margin-left: 8px;
   }
 }

--- a/packages/marketplace/src/styles/components/_grid.scss
+++ b/packages/marketplace/src/styles/components/_grid.scss
@@ -19,6 +19,9 @@
 
 .marketplace-header__right, .marketplace-header__left {
   display: flex;
+  & > * {
+    margin-left: 8px;
+  }
 }
 
 .marketplace-header__left {
@@ -99,7 +102,6 @@
   color: var(--spice-text);
   display: inline-block;
   padding: 10px 14px 6px;
-  margin-left: 8px;
   font-weight: bold;
   position: relative;
   text-decoration: none !important;
@@ -116,7 +118,6 @@
 
 // Search bar
 .searchbar--bar__wrapper {
-  margin-left: 8px;
   display: flex;
   flex-direction: column;
   align-items: flex-end;


### PR DESCRIPTION
Apply `margin-left` for every element placed in Heading instead of explicitly declaring them for each element.
Fix current `margin-left` problem also.
![image](https://user-images.githubusercontent.com/77577746/179339562-a33d54cb-6dc2-4425-8cd8-43369876fa3a.png)
