### PR TITLE
fix(grid): card filter on search

### DIFF
--- a/packages/marketplace/src/components/Grid.tsx
+++ b/packages/marketplace/src/components/Grid.tsx
@@ -560,10 +560,8 @@ export default class Grid extends React.Component<
                 user?.toLowerCase().includes(searchValue.trim().toLowerCase()))
                 return card;
             })
-            .map((card, index) => {
+            .map((card) => {
               // Clone the cards and update the prop to trigger re-render
-              // TODO: is it possible to only re-render the theme cards whose status have changed?
-              card.key = index;
               const cardElement = React.cloneElement(card, {
                 activeThemeKey: this.state.activeThemeKey,
               });


### PR DESCRIPTION
When typing in search textbox, items in `Grid` is changed visually (except star count). But when you press install button, it installs item at position in initial list.

Example:
- Open Marketplace, Extensions tab
- Enter `copy` in search textbox
- Press Install at `Copy to Clipboard`, console log says it installed Hide Podcasts extension

https://user-images.githubusercontent.com/31266357/180731330-d2b299da-196c-425d-8fd0-2a80561cbda5.mp4

After fix:

https://user-images.githubusercontent.com/31266357/180731865-916543e3-2aba-4ae7-95d3-83b4da503f6a.mp4
