### PR TITLE
fix(Grid): only re-render cards on state change

### DIFF
--- a/packages/marketplace/src/components/Card/Card.tsx
+++ b/packages/marketplace/src/components/Card/Card.tsx
@@ -8,6 +8,7 @@ import {
   initializeSnippets,
   parseCSS,
   injectUserCSS,
+  generateKey,
 } from "../../logic/Utils";
 import TrashIcon from "../Icons/TrashIcon";
 import DownloadIcon from "../Icons/DownloadIcon";
@@ -26,7 +27,6 @@ export type CardProps = {
   updateActiveTheme: (string) => void;
   type: CardType;
   visual: VisualConfig;
-  key: string;
   activeThemeKey?: string;
 };
 
@@ -60,25 +60,7 @@ export default class Card extends React.Component<CardProps, {
     // this.menuType = Spicetify.ReactComponent.Menu | "div";
     this.menuType = Spicetify.ReactComponent.Menu;
 
-    const prefix = props.type === "snippet" ? "snippet:" : `${props.item.user}/${props.item.repo}/`;
-
-    let cardId: string;
-    switch (props.type) {
-    case "snippet":
-      cardId = props.item.title.replaceAll(" ", "-");
-      break;
-    case "theme":
-      cardId = props.item.manifest?.usercss || "";
-      break;
-    case "extension":
-      cardId = props.item.manifest?.main || "";
-      break;
-    case "app":
-      cardId = props.item.manifest?.name?.replaceAll(" ", "-") || "";
-      break;
-    }
-
-    this.localStorageKey = `marketplace:installed:${prefix}${cardId}`;
+    this.localStorageKey = generateKey(props);
 
     Object.assign(this, props);
 

--- a/packages/marketplace/src/components/Grid.tsx
+++ b/packages/marketplace/src/components/Grid.tsx
@@ -3,7 +3,7 @@ import semver from "semver";
 import { Option } from "react-dropdown";
 
 import { CardItem, CardType, Config, SchemeIni, Snippet, TabItemConfig } from "../types/marketplace-types";
-import { getLocalStorageDataFromKey, generateSchemesOptions, injectColourScheme } from "../logic/Utils";
+import { getLocalStorageDataFromKey, generateSchemesOptions, injectColourScheme, generateKey } from "../logic/Utils";
 import { LOCALSTORAGE_KEYS, ITEMS_PER_REQUEST, MARKETPLACE_VERSION, LATEST_RELEASE } from "../constants";
 import { openModal } from "../logic/LaunchModals";
 import {
@@ -562,10 +562,9 @@ export default class Grid extends React.Component<
             })
             .map((card) => {
               // Clone the cards and update the prop to trigger re-render
-
               return React.cloneElement(card, {
                 activeThemeKey: this.state.activeThemeKey,
-                key: `${card.props.item.title}-${card.props.item.user}`,
+                key: generateKey(card.props),
               });
             });
 

--- a/packages/marketplace/src/components/Grid.tsx
+++ b/packages/marketplace/src/components/Grid.tsx
@@ -562,10 +562,11 @@ export default class Grid extends React.Component<
             })
             .map((card) => {
               // Clone the cards and update the prop to trigger re-render
-              const cardElement = React.cloneElement(card, {
+
+              return React.cloneElement(card, {
                 activeThemeKey: this.state.activeThemeKey,
+                key: `${card.props.item.title}-${card.props.item.user}`,
               });
-              return cardElement;
             });
 
           if (cardsOfType.length) {

--- a/packages/marketplace/src/logic/Utils.ts
+++ b/packages/marketplace/src/logic/Utils.ts
@@ -1,3 +1,4 @@
+import { CardProps } from "../components/Card/Card";
 import { Author, CardItem, ColourScheme, SchemeIni, Snippet, SortBoxOption } from "../types/marketplace-types";
 
 /**
@@ -409,4 +410,26 @@ export async function getMarkdownHTML(markdown: string, user: string, repo: stri
 // This function is used to sleep for a certain amount of time
 export function sleep(ms: number | undefined) {
   return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export function generateKey(props: CardProps) {
+  const prefix = props.type === "snippet" ? "snippet:" : `${props.item.user}/${props.item.repo}/`;
+
+  let cardId: string;
+  switch (props.type) {
+  case "snippet":
+    cardId = props.item.title.replaceAll(" ", "-");
+    break;
+  case "theme":
+    cardId = props.item.manifest?.usercss || "";
+    break;
+  case "extension":
+    cardId = props.item.manifest?.main || "";
+    break;
+  case "app":
+    cardId = props.item.manifest?.name?.replaceAll(" ", "-") || "";
+    break;
+  }
+
+  return `marketplace:installed:${prefix}${cardId}`;
 }


### PR DESCRIPTION
Resolves #106 
~~this is part of the reason why cards refused to re-render on search lol~~ as React won't render new components if they have the same key.