### PR TITLE
fix(settings): compatibility with other extensions

### DIFF
--- a/packages/marketplace/src/styles/components/_settings.scss
+++ b/packages/marketplace/src/styles/components/_settings.scss
@@ -1,4 +1,4 @@
-.setting-row {
+#marketplace-config-container .setting-row {
   display: flex;
   justify-content: space-between;
 


### PR DESCRIPTION
Breaks other extensions & custom apps stylings after visiting Marketplace
![image](https://user-images.githubusercontent.com/77577746/185529705-aa2ad5d9-4eab-4d51-824f-939e90879f38.png)
Marketplace CSS applied globally:
![image](https://user-images.githubusercontent.com/77577746/185529796-0b0aec10-0393-4e7c-98e4-c03ba112d22f.png)
