### PR TITLE
style(grid): Add space between + and “Add CSS”

### DIFF
--- a/packages/marketplace/src/components/Grid.tsx
+++ b/packages/marketplace/src/components/Grid.tsx
@@ -592,7 +592,7 @@ class Grid extends React.Component<
         })}
         {/* Add snippets button if on snippets tab */}
         {this.CONFIG.activeTab === "Snippets"
-          ? <Button classes={["marketplace-add-snippet-btn"]} onClick={() => openModal("ADD_SNIPPET")}>+{t("grid.addCSS")}</Button>
+          ? <Button classes={["marketplace-add-snippet-btn"]} onClick={() => openModal("ADD_SNIPPET")}>+ {t("grid.addCSS")}</Button>
           : null}
         <footer className="marketplace-footer">
           {!this.state.endOfList && (this.state.rest ? <LoadMoreIcon onClick={this.loadMore.bind(this)} /> : <LoadingIcon />)}


### PR DESCRIPTION
Not too compact.

## Before

<img width="228" alt="image" src="https://user-images.githubusercontent.com/28441561/189060879-95db614d-531d-4ee1-a503-47c834b842d1.png">

## After

<img width="252" alt="image" src="https://user-images.githubusercontent.com/28441561/189060644-b783df0b-e0c1-44ad-aae9-9c40c10ff8b5.png">