### PR TITLE
fix: handling username with special characters

### DIFF
--- a/resources/install.ps1
+++ b/resources/install.ps1
@@ -9,7 +9,7 @@ if ($null -eq $checkSpice) {
   Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/khanhas/spicetify-cli/master/install.ps1" | Invoke-Expression
 }
 
-$spicePath = spicetify -c | Split-Path
+$spicePath = "$env:APPDATA\spicetify"
 $sp_dot_dir = "$spicePath\CustomApps"
 if (-not (Test-Path $sp_dot_dir)) {
   Write-Host "Making a CustomApps folder..." -ForegroundColor "Cyan"


### PR DESCRIPTION
i hate powershell
![image](https://user-images.githubusercontent.com/77577746/190900685-07ab856d-d362-44db-abf4-e39263bb6015.png)
More details in spicetify/spicetify-cli#1940