### PR TITLE
feat: add `Install` button in `View Snippet` modal

### DIFF
--- a/packages/marketplace/src/components/Card/Card.tsx
+++ b/packages/marketplace/src/components/Card/Card.tsx
@@ -426,7 +426,7 @@ class Card extends React.Component<CardProps, {
           if (getLocalStorageDataFromKey(`marketplace:installed:snippet:${processedName}`)?.custom)
             return openModal("EDIT_SNIPPET", undefined, undefined, this.props);
 
-          openModal("VIEW_SNIPPET", undefined, undefined, this.props);
+          openModal("VIEW_SNIPPET", undefined, undefined, this.props, this.buttonClicked.bind(this));
         } else this.openReadme();
       }
       }>

--- a/packages/marketplace/src/components/Modals/Snippet/index.tsx
+++ b/packages/marketplace/src/components/Modals/Snippet/index.tsx
@@ -14,7 +14,7 @@ import Button from "../../Button";
 import { CardProps } from "../../Card/Card";
 import { ModalType } from "../../../logic/LaunchModals";
 
-const SnippetModal = (props: { content?: CardProps, type: ModalType }) => {
+const SnippetModal = (props: { content?: CardProps, type: ModalType, callback?: () => void }) => {
   const PREVIEW_IMAGE_ID = "marketplace-customCSS-preview";
   const [code, setCode] = React.useState(props.type === "ADD_SNIPPET" ? "" : props.content?.item.code || "");
   const [name, setName] = React.useState(props.type === "ADD_SNIPPET" ? "" : props.content?.item.title || "");
@@ -24,13 +24,15 @@ const SnippetModal = (props: { content?: CardProps, type: ModalType }) => {
   const processName = () => name.replace(/\n/g, "").replaceAll(" ", "-");
   const processCode = () => code.replace(/\n/g, "\\n");
 
+  const localStorageKey = `marketplace:installed:snippet:${processName()}`;
+  const [isInstalled, setInstalled] = React.useState(!!getLocalStorageDataFromKey(localStorageKey));
+
   const saveSnippet = () => {
     // const processedCode = processCode();
     const processedName = processName();
     const processedDescription = description.trim();
 
-    const localStorageKey = `marketplace:installed:snippet:${processedName}`;
-    if (getLocalStorageDataFromKey(localStorageKey) && props.type !== "EDIT_SNIPPET") {
+    if (isInstalled && props.type !== "EDIT_SNIPPET") {
       Spicetify.showNotification("That name is already taken!", true);
       return;
     }
@@ -166,6 +168,13 @@ const SnippetModal = (props: { content?: CardProps, type: ModalType }) => {
               {t("snippets.saveCSS")}
             </Button>
           </>
+      }
+      {
+        props.type === "VIEW_SNIPPET"
+          &&
+          <Button onClick={() => {props.callback && props.callback(); setInstalled(!isInstalled);}}>
+            {isInstalled ? t("remove") : t("install")}
+          </Button>
       }
     </div>
   );

--- a/packages/marketplace/src/logic/LaunchModals.tsx
+++ b/packages/marketplace/src/logic/LaunchModals.tsx
@@ -16,6 +16,7 @@ const getModalSettings = (
   CONFIG?: Config,
   updateAppConfig?: (CONFIG: Config) => void,
   props?: CardProps,
+  callback?: () => void,
 ) => {
   switch (modalType) {
   case "ADD_SNIPPET":
@@ -33,7 +34,7 @@ const getModalSettings = (
   case "VIEW_SNIPPET":
     return {
       title: t("snippets.viewTitle"),
-      content: <SnippetModal type={modalType} content={props as CardProps} />,
+      content: <SnippetModal type={modalType} content={props as CardProps} callback={callback} />,
       isLarge: true,
     };
   case "RELOAD":
@@ -76,9 +77,10 @@ export const openModal = (
   CONFIG?: Config,
   updateAppConfig?: (CONFIG: Config) => void,
   props?: CardProps,
+  callback?: () => void,
 ) => {
   const triggerModal = () => {
-    const modalSettings = getModalSettings(modal, CONFIG, updateAppConfig, props);
+    const modalSettings = getModalSettings(modal, CONFIG, updateAppConfig, props, callback);
     Spicetify.PopupModal.display(modalSettings);
   };
 


### PR DESCRIPTION
For the same reason we added the `Install` button inside Readme pages, plus a small number of users were reporting that they couldn't get the Install/Remove button to display when hovering over cards when there aren't any alternative ways of doing the same thing.
![uEMowyHOHu](https://user-images.githubusercontent.com/77577746/201901052-96250bfd-7f8f-4c18-b74f-d8b398ac8e2a.gif)
