### PR TITLE
feat: Album-Art Based Color Shifting

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,5 +15,9 @@
 	"packageManager": "yarn@3.2.1",
 	"devDependencies": {
 		"husky": "^8.0.2"
+	},
+	"dependencies": {
+		"@types/chroma-js": "^2.1.4",
+		"chroma-js": "^2.4.2"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -15,9 +15,5 @@
 	"packageManager": "yarn@3.2.1",
 	"devDependencies": {
 		"husky": "^8.0.2"
-	},
-	"dependencies": {
-		"@types/chroma-js": "^2.1.4",
-		"chroma-js": "^2.4.2"
 	}
 }

--- a/packages/marketplace/package.json
+++ b/packages/marketplace/package.json
@@ -45,5 +45,8 @@
 		"spicetify-creator": "^1.0.11",
 		"typescript": "^4.9.3"
 	},
-	"private": true
+	"private": true,
+	"dependencies": {
+		"node-vibrant": "3.1.4"
+	}
 }

--- a/packages/marketplace/package.json
+++ b/packages/marketplace/package.json
@@ -24,6 +24,7 @@
 		"node": ">=16"
 	},
 	"devDependencies": {
+		"@types/chroma-js": "^2.1.4",
 		"@types/filesystem": "^0.0.32",
 		"@types/react": "^17.0.2",
 		"@types/react-dom": "^17.0.2",
@@ -31,11 +32,13 @@
 		"@types/wicg-file-system-access": "^2020.9.5",
 		"@typescript-eslint/eslint-plugin": "^5.45.0",
 		"@typescript-eslint/parser": "^5.45.0",
+		"chroma-js": "^2.4.2",
 		"copyfiles": "^2.4.1",
 		"eslint": "^8.28.0",
 		"eslint-plugin-react": "^7.31.11",
 		"i18next": "^22.0.6",
 		"i18next-browser-languagedetector": "^7.0.1",
+		"node-vibrant": "3.1.4",
 		"prismjs": "^1.29.0",
 		"react-dropdown": "^1.11.0",
 		"react-i18next": "^12.0.0",
@@ -45,8 +48,5 @@
 		"spicetify-creator": "^1.0.11",
 		"typescript": "^4.9.3"
 	},
-	"private": true,
-	"dependencies": {
-		"node-vibrant": "3.1.4"
-	}
+	"private": true
 }

--- a/packages/marketplace/src/app.tsx
+++ b/packages/marketplace/src/app.tsx
@@ -115,6 +115,7 @@ class App extends React.Component<{
         colorShift: JSON.parse(getLocalStorageDataFromKey("marketplace:colorShift", false)),
         themeDevTools: JSON.parse(getLocalStorageDataFromKey("marketplace:themeDevTools", false)),
         albumArtBasedColors: JSON.parse(getLocalStorageDataFromKey("marketplace:albumArtBasedColors", false)),
+        albumArtBasedColorsMode: getLocalStorageDataFromKey("marketplace:albumArtBasedColorsMode") || "monochrome-light",
         // Legacy from reddit app
         type: JSON.parse(getLocalStorageDataFromKey("marketplace:type", false)),
         // I was considering adding watchers as "followers" but it looks like the value is a duplicate

--- a/packages/marketplace/src/app.tsx
+++ b/packages/marketplace/src/app.tsx
@@ -114,6 +114,7 @@ class App extends React.Component<{
         hideInstalled: JSON.parse(getLocalStorageDataFromKey("marketplace:hideInstalled", false)),
         colorShift: JSON.parse(getLocalStorageDataFromKey("marketplace:colorShift", false)),
         themeDevTools: JSON.parse(getLocalStorageDataFromKey("marketplace:themeDevTools", false)),
+        albumArtBasedColors: JSON.parse(getLocalStorageDataFromKey("marketplace:albumArtBasedColors", false)),
         // Legacy from reddit app
         type: JSON.parse(getLocalStorageDataFromKey("marketplace:type", false)),
         // I was considering adding watchers as "followers" but it looks like the value is a duplicate

--- a/packages/marketplace/src/components/Modals/Settings/ConfigRow.tsx
+++ b/packages/marketplace/src/components/Modals/Settings/ConfigRow.tsx
@@ -9,11 +9,11 @@ const ConfigRow = (props: {
   modalConfig: Config;
   clickable?: boolean;
   updateConfig: (CONFIG: Config) => void;
-  type: string | null;
-  options: string[] | null;
+  type?: string;
+  options?: string[];
 }) => {
   const type = props.type;
-  const componentId = type == "dropdown" ? "dropdown:" +props.storageKey : "toggle:" + props.storageKey;
+  const componentId = type === "dropdown" ? "dropdown:" + props.storageKey : "toggle:" + props.storageKey;
   const enabled = !!props.modalConfig.visual[props.storageKey];
 
   const settingsToggleChange = (e) => {

--- a/packages/marketplace/src/components/Modals/Settings/ConfigRow.tsx
+++ b/packages/marketplace/src/components/Modals/Settings/ConfigRow.tsx
@@ -13,7 +13,9 @@ const ConfigRow = (props: {
   options?: string[];
 }) => {
   const type = props.type;
-  const componentId = type === "dropdown" ? "dropdown:" + props.storageKey : "toggle:" + props.storageKey;
+  const componentId = (type === "dropdown")
+    ? "dropdown:" + props.storageKey
+    : "toggle:" + props.storageKey;
   const enabled = !!props.modalConfig.visual[props.storageKey];
 
   const settingsToggleChange = (e) => {

--- a/packages/marketplace/src/components/Modals/Settings/ConfigRow.tsx
+++ b/packages/marketplace/src/components/Modals/Settings/ConfigRow.tsx
@@ -35,10 +35,9 @@ const ConfigRow = (props: {
     props.updateConfig(props.modalConfig);
   };
 
-  if (type == "dropdown" && props.options != null) {
+  if (type === "dropdown" && props.options) {
     return (
       <SortBox
-
         sortBoxOptions={props.options.map((option) => {
           return {
             key: option,

--- a/packages/marketplace/src/components/Modals/Settings/ConfigRow.tsx
+++ b/packages/marketplace/src/components/Modals/Settings/ConfigRow.tsx
@@ -2,15 +2,18 @@ import React from "react";
 import { Config } from "../../../types/marketplace-types";
 
 import Toggle from "../../Toggle";
-
+import SortBox from "../../Sortbox";
 const ConfigRow = (props: {
   name: string;
   storageKey: string;
   modalConfig: Config;
   clickable?: boolean;
   updateConfig: (CONFIG: Config) => void;
+  type: string | null;
+  options: string[] | null;
 }) => {
-  const toggleId = `toggle:${props.storageKey}`;
+  const type = props.type;
+  const componentId = type == "dropdown" ? "dropdown:" +props.storageKey : "toggle:" + props.storageKey;
   const enabled = !!props.modalConfig.visual[props.storageKey];
 
   const settingsToggleChange = (e) => {
@@ -24,10 +27,35 @@ const ConfigRow = (props: {
     props.updateConfig(props.modalConfig);
     // gridUpdatePostsVisual && gridUpdatePostsVisual();
   };
+  const settingsDropdownChange = (value) => {
+    const state = value;
+    const storageKey = props.storageKey;
+    props.modalConfig.visual[storageKey] = state;
+    localStorage.setItem(`marketplace:${storageKey}`, String(state));
+    props.updateConfig(props.modalConfig);
+  };
 
+  if (type == "dropdown" && props.options != null) {
+    return (
+      <SortBox
+
+        sortBoxOptions={props.options.map((option) => {
+          return {
+            key: option,
+            value: option,
+          };
+        })}
+        onChange={(value) => settingsDropdownChange(value)}
+        sortBySelectedFn={(item) => {
+          return item.key == props.modalConfig.visual[props.storageKey];
+        }}
+      />
+
+    );
+  }
   return (
     <div className='setting-row'>
-      <label htmlFor={toggleId} className='col description'>{props.name}</label>
+      <label htmlFor={componentId} className='col description'>{props.name}</label>
       <div className='col action'>
         <Toggle name={props.name} storageKey={props.storageKey} enabled={enabled} onChange={settingsToggleChange} />
       </div>

--- a/packages/marketplace/src/components/Modals/Settings/index.tsx
+++ b/packages/marketplace/src/components/Modals/Settings/index.tsx
@@ -43,12 +43,15 @@ const SettingsModal = ({ CONFIG, updateAppConfig } : Props) => {
   return (
     <div id="marketplace-config-container">
       <h2>{t("settings.optionsHeading")}</h2>
-      <ConfigRow name={t("settings.starCountLabel")} storageKey='stars' modalConfig={modalConfig} updateConfig={updateConfig} />
-      <ConfigRow name={t("settings.tagsLabel")} storageKey='tags' modalConfig={modalConfig} updateConfig={updateConfig} />
-      <ConfigRow name={t("settings.devToolsLabel")} storageKey='themeDevTools' modalConfig={modalConfig} updateConfig={updateConfig} />
-      <ConfigRow name={t("settings.hideInstalledLabel")} storageKey='hideInstalled' modalConfig={modalConfig} updateConfig={updateConfig} />
-      <ConfigRow name={t("settings.colourShiftLabel")} storageKey='colorShift' modalConfig={modalConfig} updateConfig={updateConfig} />
-      <ConfigRow name={t("settings.albumArtBasedColors")} storageKey='albumArtBasedColors' modalConfig={modalConfig} updateConfig={updateConfig} />
+      <ConfigRow name={t("settings.starCountLabel")} storageKey='stars' modalConfig={modalConfig} updateConfig={updateConfig} type={null} options={null} />
+      <ConfigRow name={t("settings.tagsLabel")} storageKey='tags' modalConfig={modalConfig} updateConfig={updateConfig} type={null} options={null} />
+      <ConfigRow name={t("settings.devToolsLabel")} storageKey='themeDevTools' modalConfig={modalConfig} updateConfig={updateConfig} type={null} options={null} />
+      <ConfigRow name={t("settings.hideInstalledLabel")} storageKey='hideInstalled' modalConfig={modalConfig} updateConfig={updateConfig} type={null} options={null} />
+      <ConfigRow name={t("settings.colourShiftLabel")} storageKey='colorShift' modalConfig={modalConfig} updateConfig={updateConfig} type={null} options={null} />
+      <ConfigRow name={t("settings.albumArtBasedColors")} storageKey='albumArtBasedColors' modalConfig={modalConfig} updateConfig={updateConfig} type={null} options={null} />
+      {/* Make options monochrome-dark ,monochrome-light ,analogic complement ,analogic-complement ,triad ,quad*/}
+      <ConfigRow name={t("settings.albumArtBasedColorsMode")} storageKey='albumArtBasedColorsMode' modalConfig=
+        {modalConfig} updateConfig={updateConfig} type="dropdown" options={["monochromeDark", "monochromeLight", "analogicComplement", "analogic", "triad", "quad"]} />
       <h2>{t("settings.tabsHeading")}</h2>
       <div className="tabs-container">
         {modalConfig.tabs.map(({ name }, index) => {

--- a/packages/marketplace/src/components/Modals/Settings/index.tsx
+++ b/packages/marketplace/src/components/Modals/Settings/index.tsx
@@ -48,6 +48,7 @@ const SettingsModal = ({ CONFIG, updateAppConfig } : Props) => {
       <ConfigRow name={t("settings.devToolsLabel")} storageKey='themeDevTools' modalConfig={modalConfig} updateConfig={updateConfig} />
       <ConfigRow name={t("settings.hideInstalledLabel")} storageKey='hideInstalled' modalConfig={modalConfig} updateConfig={updateConfig} />
       <ConfigRow name={t("settings.colourShiftLabel")} storageKey='colorShift' modalConfig={modalConfig} updateConfig={updateConfig} />
+      <ConfigRow name={t("settings.albumArtBasedColors")} storageKey='albumArtBasedColors' modalConfig={modalConfig} updateConfig={updateConfig} />
       <h2>{t("settings.tabsHeading")}</h2>
       <div className="tabs-container">
         {modalConfig.tabs.map(({ name }, index) => {

--- a/packages/marketplace/src/components/Modals/Settings/index.tsx
+++ b/packages/marketplace/src/components/Modals/Settings/index.tsx
@@ -43,12 +43,12 @@ const SettingsModal = ({ CONFIG, updateAppConfig } : Props) => {
   return (
     <div id="marketplace-config-container">
       <h2>{t("settings.optionsHeading")}</h2>
-      <ConfigRow name={t("settings.starCountLabel")} storageKey='stars' modalConfig={modalConfig} updateConfig={updateConfig} type={null} options={null} />
-      <ConfigRow name={t("settings.tagsLabel")} storageKey='tags' modalConfig={modalConfig} updateConfig={updateConfig} type={null} options={null} />
-      <ConfigRow name={t("settings.devToolsLabel")} storageKey='themeDevTools' modalConfig={modalConfig} updateConfig={updateConfig} type={null} options={null} />
-      <ConfigRow name={t("settings.hideInstalledLabel")} storageKey='hideInstalled' modalConfig={modalConfig} updateConfig={updateConfig} type={null} options={null} />
-      <ConfigRow name={t("settings.colourShiftLabel")} storageKey='colorShift' modalConfig={modalConfig} updateConfig={updateConfig} type={null} options={null} />
-      <ConfigRow name={t("settings.albumArtBasedColors")} storageKey='albumArtBasedColors' modalConfig={modalConfig} updateConfig={updateConfig} type={null} options={null} />
+      <ConfigRow name={t("settings.starCountLabel")} storageKey='stars' modalConfig={modalConfig} updateConfig={updateConfig}/>
+      <ConfigRow name={t("settings.tagsLabel")} storageKey='tags' modalConfig={modalConfig} updateConfig={updateConfig}/>
+      <ConfigRow name={t("settings.devToolsLabel")} storageKey='themeDevTools' modalConfig={modalConfig} updateConfig={updateConfig}/>
+      <ConfigRow name={t("settings.hideInstalledLabel")} storageKey='hideInstalled' modalConfig={modalConfig} updateConfig={updateConfig}/>
+      <ConfigRow name={t("settings.colourShiftLabel")} storageKey='colorShift' modalConfig={modalConfig} updateConfig={updateConfig}/>
+      <ConfigRow name={t("settings.albumArtBasedColors")} storageKey='albumArtBasedColors' modalConfig={modalConfig} updateConfig={updateConfig}/>
       {/* Make options monochrome-dark ,monochrome-light ,analogic complement ,analogic-complement ,triad ,quad*/}
       <ConfigRow name={t("settings.albumArtBasedColorsMode")} storageKey='albumArtBasedColorsMode' modalConfig=
         {modalConfig} updateConfig={updateConfig} type="dropdown" options={["monochromeDark", "monochromeLight", "analogicComplement", "analogic", "triad", "quad"]} />

--- a/packages/marketplace/src/constants.ts
+++ b/packages/marketplace/src/constants.ts
@@ -12,6 +12,7 @@ export const LOCALSTORAGE_KEYS = {
   sortBy: "marketplace:sort-by",
   // Theme installed store the localsorage key of the theme (e.g. marketplace:installed:NYRI4/Comfy-spicetify/user.css)
   themeInstalled: "marketplace:theme-installed",
+  albumArtBasedColor: "marketplace:albumArtBasedColors",
   colorShift: "marketplace:colorShift",
 };
 

--- a/packages/marketplace/src/constants.ts
+++ b/packages/marketplace/src/constants.ts
@@ -13,7 +13,9 @@ export const LOCALSTORAGE_KEYS = {
   // Theme installed store the localsorage key of the theme (e.g. marketplace:installed:NYRI4/Comfy-spicetify/user.css)
   themeInstalled: "marketplace:theme-installed",
   albumArtBasedColor: "marketplace:albumArtBasedColors",
+  albumArtBasedColorMode: "marketplace:albumArtBasedColorsMode",
   colorShift: "marketplace:colorShift",
+
 };
 
 // Initalize topbar tabs

--- a/packages/marketplace/src/constants.ts
+++ b/packages/marketplace/src/constants.ts
@@ -15,7 +15,6 @@ export const LOCALSTORAGE_KEYS = {
   albumArtBasedColor: "marketplace:albumArtBasedColors",
   albumArtBasedColorMode: "marketplace:albumArtBasedColorsMode",
   colorShift: "marketplace:colorShift",
-
 };
 
 // Initalize topbar tabs

--- a/packages/marketplace/src/extensions/extension.tsx
+++ b/packages/marketplace/src/extensions/extension.tsx
@@ -19,6 +19,7 @@ import {
   addToSessionStorage,
   sleep,
   addExtensionToSpicetifyConfig,
+  initAlbumArtBasedColor,
 } from "../logic/Utils";
 import {
   getBlacklist,
@@ -91,6 +92,10 @@ import {
 
       // Add to Spicetify.Config
       Spicetify.Config.color_scheme = themeManifest.activeScheme;
+      if (localStorage.getItem(LOCALSTORAGE_KEYS.albumArtBasedColor) === "true") {
+        initAlbumArtBasedColor(activeScheme);
+        return;
+      }
 
       if (localStorage.getItem(LOCALSTORAGE_KEYS.colorShift) === "true") {
         initColorShiftLoop(themeManifest.schemes);

--- a/packages/marketplace/src/extensions/extension.tsx
+++ b/packages/marketplace/src/extensions/extension.tsx
@@ -94,8 +94,7 @@ import {
       Spicetify.Config.color_scheme = themeManifest.activeScheme;
       if (localStorage.getItem(LOCALSTORAGE_KEYS.albumArtBasedColor) === "true") {
         initAlbumArtBasedColor(activeScheme);
-      }
-      else if (localStorage.getItem(LOCALSTORAGE_KEYS.colorShift) === "true") {
+      } else if (localStorage.getItem(LOCALSTORAGE_KEYS.colorShift) === "true") {
         initColorShiftLoop(themeManifest.schemes);
       }
     } else {

--- a/packages/marketplace/src/extensions/extension.tsx
+++ b/packages/marketplace/src/extensions/extension.tsx
@@ -94,10 +94,8 @@ import {
       Spicetify.Config.color_scheme = themeManifest.activeScheme;
       if (localStorage.getItem(LOCALSTORAGE_KEYS.albumArtBasedColor) === "true") {
         initAlbumArtBasedColor(activeScheme);
-        return;
       }
-
-      if (localStorage.getItem(LOCALSTORAGE_KEYS.colorShift) === "true") {
+      else if (localStorage.getItem(LOCALSTORAGE_KEYS.colorShift) === "true") {
         initColorShiftLoop(themeManifest.schemes);
       }
     } else {

--- a/packages/marketplace/src/logic/Utils.ts
+++ b/packages/marketplace/src/logic/Utils.ts
@@ -328,7 +328,6 @@ export const getColorFromImage = async (image: HTMLImageElement, numColors : num
   if (swatches.Vibrant) {
     // remove the # from the hex
     return swatches.Vibrant.hex.substring(1);
-
   }
   return "null";
 

--- a/packages/marketplace/src/logic/Utils.ts
+++ b/packages/marketplace/src/logic/Utils.ts
@@ -2,6 +2,7 @@ import { CardProps } from "../components/Card/Card";
 import { Author, CardItem, ColourScheme, SchemeIni, Snippet, SortBoxOption } from "../types/marketplace-types";
 import Vibrant from "node-vibrant";
 import Chroma from "chroma-js";
+import { LOCALSTORAGE_KEYS } from "../constants";
 /**
  * Get localStorage data (or fallback value), given a key
  * @param key The localStorage key
@@ -317,7 +318,7 @@ export const initColorShiftLoop = (schemes: SchemeIni) => {
   }, 60 * 1000);
 };
 
-export const getColorFromImage = async (image: HTMLImageElement, numColors : number) => {
+export const getColorFromImage = async (image: HTMLImageElement, numColors: number) => {
   const swatches = await Vibrant.from(image).maxColorCount(numColors).getPalette((err, palette) => {
     if (err) {
       console.error(err);
@@ -325,17 +326,18 @@ export const getColorFromImage = async (image: HTMLImageElement, numColors : num
     }
     return palette;
   });
+
   if (swatches.Vibrant) {
     // remove the # from the hex
     return swatches.Vibrant.hex.substring(1);
   }
-  return "null";
 
+  return "null";
 };
 
-export const generateColorPalette = async (mainColor : string, numColors : number) => {
+export const generateColorPalette = async (mainColor: string, numColors: number) => {
   // Generate a palette from https://www.thecolorapi.com/id?hex=0047AB&rgb=0,71,171&hsl=215,100%,34%&cmyk=100,58,0,33&format=html
-  const mode = getLocalStorageDataFromKey("marketplace:albumArtBasedColorsMode");
+  const mode = getLocalStorageDataFromKey(LOCALSTORAGE_KEYS.albumArtBasedColorMode);
   // Add a hyphen before any uppercase characters
   const modeStr = mode.replace(/([A-Z])/g, "-$1").toLowerCase();
   //fetch `https://www.thecolorapi.com/scheme?hex=${mainColor}&mode=${modeStr}&count=${numColors}`
@@ -346,11 +348,11 @@ export const generateColorPalette = async (mainColor : string, numColors : numbe
   return colorArray;
 };
 
-async function waitForAlbumArt() : Promise<HTMLImageElement | null> {
+async function waitForAlbumArt(): Promise<HTMLImageElement | null> {
   // Only return when the album art is loaded
   return new Promise((resolve) => {
     setInterval(() => {
-      const albumArt : HTMLImageElement | null  = document.querySelector(".main-image-image.cover-art-image");
+      const albumArt: HTMLImageElement | null = document.querySelector(".main-image-image.cover-art-image");
       if (albumArt) {
         resolve(albumArt);
       }
@@ -373,7 +375,7 @@ export const initAlbumArtBasedColor = (scheme: ColourScheme) => {
   document.body.appendChild(style);
   Spicetify.Player.addEventListener("songchange", async () => {
     await sleep(1000);
-    let albumArt : HTMLImageElement | null = document.querySelector(".main-image-image.cover-art-image");
+    let albumArt: HTMLImageElement | null = document.querySelector(".main-image-image.cover-art-image");
 
     // If it doesn't exist, wait for it to load
     if (albumArt == null || !albumArt.complete) {
@@ -399,12 +401,11 @@ export const initAlbumArtBasedColor = (scheme: ColourScheme) => {
       }
       // Order the color map by how similar the colors are to eachother
       const orderedColorMap = new Map([...colorMap.entries()].sort((a, b) => {
-
         const aColor = Chroma(a[0]);
         const bColor = Chroma(b[0]);
         return aColor.get("lab.l") - bColor.get("lab.l");
       }));
-      colorMap=orderedColorMap;
+      colorMap = orderedColorMap;
       // replace the keys in the color map with the new colors
       const newScheme = {};
       for (const [, value] of colorMap.entries()) {
@@ -416,9 +417,7 @@ export const initAlbumArtBasedColor = (scheme: ColourScheme) => {
         }
       }
       injectColourScheme(newScheme);
-
     }
-
   });
 };
 

--- a/packages/marketplace/src/logic/Utils.ts
+++ b/packages/marketplace/src/logic/Utils.ts
@@ -312,7 +312,6 @@ export const initColorShiftLoop = (schemes: SchemeIni) => {
     }`;
 
     document.body.appendChild(style);
-    console.log(Object.values(schemes)[i]);
     injectColourScheme(Object.values(schemes)[i]);
     i++;
     style.remove();
@@ -327,7 +326,6 @@ export const getColorFromImage = async (image: HTMLImageElement, numColors : num
     }
   });
   if (swatches.Vibrant) {
-    console.log(swatches.Vibrant.hex);
     // remove the # from the hex
     return swatches.Vibrant.hex.substring(1);
 
@@ -341,7 +339,6 @@ export const generateColorPalette = async (mainColor : string, numColors : numbe
   console.log(`Generating color palette for ${mainColor}`);
   const palette = await fetch(`https://www.thecolorapi.com/scheme?hex=${mainColor}&mode=monochrome-light&count=${numColors}`);
   const paletteJSON = await palette.json();
-  console.log(paletteJSON);
   // create an array of the hex values for the colors while also removing the #
   const colorArray = paletteJSON.colors.map((color) => color.hex.value.substring(1));
   return colorArray;
@@ -372,20 +369,16 @@ export const initAlbumArtBasedColor = (scheme: ColourScheme) => {
   // and update the color scheme accordingly
   document.body.appendChild(style);
   Spicetify.Player.addEventListener("songchange", async () => {
-    await sleep(2000);
-    console.log("Triggering color change");
+    await sleep(1000);
     let albumArt : HTMLImageElement | null = document.querySelector(".main-image-image.cover-art-image");
-    console.log(albumArt);
 
     // If it doesn't exist, wait for it to load
     if (albumArt == null || !albumArt.complete) {
-      console.log("Waiting for album art to load");
       albumArt = await waitForAlbumArt();
     }
 
     if (albumArt) {
       const numColors = new Set(Object.values(scheme)).size;
-      console.log(numColors);
       const mainColor = await getColorFromImage(albumArt, numColors);
       const newColors = await generateColorPalette(mainColor, numColors);
       /*  Find which keys share the same value in the current scheme, create a new scheme that has the value as the key and all the keys in the old scheme as the value
@@ -393,7 +386,6 @@ export const initAlbumArtBasedColor = (scheme: ColourScheme) => {
       { "color1": "#000000", "color2": "#000000", "color3": "#FFFFFF" } ->
       { "#000000": ["color1", "color2"], "#FFFFFF": ["color3"]}
       */
-      console.log("New colors: ", newColors);
       let colorMap = new Map();
       for (const [key, value] of Object.entries(scheme)) {
         if (colorMap.has(value)) {
@@ -409,7 +401,6 @@ export const initAlbumArtBasedColor = (scheme: ColourScheme) => {
         const bColor = Chroma(b[0]);
         return aColor.get("lab.l") - bColor.get("lab.l");
       }));
-      console.log("Ordered color map: ", orderedColorMap);
       colorMap=orderedColorMap;
       // replace the keys in the color map with the new colors
       const newScheme = {};
@@ -421,7 +412,6 @@ export const initAlbumArtBasedColor = (scheme: ColourScheme) => {
           }
         }
       }
-      console.log(newScheme);
       injectColourScheme(newScheme);
 
     }

--- a/packages/marketplace/src/logic/Utils.ts
+++ b/packages/marketplace/src/logic/Utils.ts
@@ -338,10 +338,9 @@ export const getColorFromImage = async (image: HTMLImageElement, numColors : num
 export const generateColorPalette = async (mainColor : string, numColors : number) => {
   // Generate a palette from https://www.thecolorapi.com/id?hex=0047AB&rgb=0,71,171&hsl=215,100%,34%&cmyk=100,58,0,33&format=html
   console.log(`Generating color palette for ${mainColor}`);
-  const palette = await fetch(`https://www.thecolorapi.com/scheme?hex=${mainColor}&mode=monochrome-light&count=${numColors}`);
-  const paletteJSON = await palette.json();
+  const palette = await Spicetify.CosmosAsync.get(`https://www.thecolorapi.com/scheme?hex=${mainColor}&mode=monochrome-light&count=${numColors}`);
   // create an array of the hex values for the colors while also removing the #
-  const colorArray = paletteJSON.colors.map((color) => color.hex.value.substring(1));
+  const colorArray = palette.colors.map((color) => color.hex.value.substring(1));
   return colorArray;
 };
 

--- a/packages/marketplace/src/logic/Utils.ts
+++ b/packages/marketplace/src/logic/Utils.ts
@@ -324,6 +324,7 @@ export const getColorFromImage = async (image: HTMLImageElement, numColors : num
       console.error(err);
       return;
     }
+    return palette;
   });
   if (swatches.Vibrant) {
     // remove the # from the hex
@@ -404,7 +405,7 @@ export const initAlbumArtBasedColor = (scheme: ColourScheme) => {
       colorMap=orderedColorMap;
       // replace the keys in the color map with the new colors
       const newScheme = {};
-      for (const [key, value] of colorMap.entries()) {
+      for (const [, value] of colorMap.entries()) {
         const newColor = newColors.shift();
         if (newColor) {
           for (const key of value) {
@@ -580,8 +581,4 @@ export const addExtensionToSpicetifyConfig = (main?: string) => {
     Spicetify.Config.extensions.push(name);
   }
 };
-
-function resolve(albumArt: Element) {
-  throw new Error("Function not implemented.");
-}
 

--- a/packages/marketplace/src/logic/Utils.ts
+++ b/packages/marketplace/src/logic/Utils.ts
@@ -19,7 +19,6 @@ export const getLocalStorageDataFromKey = (key: string, fallback?: unknown) => {
       return data;
     }
   } else {
-    console.log(fallback);
     return fallback;
   }
 };
@@ -361,10 +360,11 @@ async function waitForAlbumArt() : Promise<HTMLImageElement | null> {
 export const initAlbumArtBasedColor = (scheme: ColourScheme) => {
   const style = document.createElement("style");
   style.className = "colorShift-style";
-  style.innerHTML = `* {
+  style.innerHTML = `
+  * {
     transition-duration: 400ms;
   }
-  main-type-bass {
+  .main-type-bass {
     transition-duration: unset !important;
   }`;
   // Add a listener for the album art changing
@@ -482,7 +482,7 @@ export const getParamsFromGithubRaw = (url: string) => {
 
 export function addToSessionStorage(items, key?) {
   if (!items) return;
-  items.forEach((item: any) => {
+  items.forEach((item) => {
     if (!key) key = `${items.user}-${items.repo}`;
     // If the key already exists, it will append to it instead of overwriting it
     const existing = window.sessionStorage.getItem(key);

--- a/packages/marketplace/src/logic/Utils.ts
+++ b/packages/marketplace/src/logic/Utils.ts
@@ -339,7 +339,9 @@ export const generateColorPalette = async (mainColor : string, numColors : numbe
   const mode = getLocalStorageDataFromKey("marketplace:albumArtBasedColorsMode");
   // Add a hyphen before any uppercase characters
   const modeStr = mode.replace(/([A-Z])/g, "-$1").toLowerCase();
-  const palette = await Spicetify.CosmosAsync.get(`https://www.thecolorapi.com/scheme?hex=${mainColor}&mode=${modeStr}&count=${numColors}`);
+  //fetch `https://www.thecolorapi.com/scheme?hex=${mainColor}&mode=${modeStr}&count=${numColors}`
+  const palette = await  fetch(`https://www.thecolorapi.com/scheme?hex=${mainColor}&mode=${modeStr}&count=${numColors}`)
+    .then((response) => response.json());
   // create an array of the hex values for the colors while also removing the #
   const colorArray = palette.colors.map((color) => color.hex.value.substring(1));
   return colorArray;

--- a/packages/marketplace/src/logic/Utils.ts
+++ b/packages/marketplace/src/logic/Utils.ts
@@ -10,7 +10,6 @@ import Chroma from "chroma-js";
  */
 export const getLocalStorageDataFromKey = (key: string, fallback?: unknown) => {
   const data = localStorage.getItem(key);
-
   if (data) {
     try {
       // If it's json parse it
@@ -20,6 +19,7 @@ export const getLocalStorageDataFromKey = (key: string, fallback?: unknown) => {
       return data;
     }
   } else {
+    console.log(fallback);
     return fallback;
   }
 };
@@ -337,8 +337,10 @@ export const getColorFromImage = async (image: HTMLImageElement, numColors : num
 
 export const generateColorPalette = async (mainColor : string, numColors : number) => {
   // Generate a palette from https://www.thecolorapi.com/id?hex=0047AB&rgb=0,71,171&hsl=215,100%,34%&cmyk=100,58,0,33&format=html
-  console.log(`Generating color palette for ${mainColor}`);
-  const palette = await Spicetify.CosmosAsync.get(`https://www.thecolorapi.com/scheme?hex=${mainColor}&mode=monochrome-light&count=${numColors}`);
+  const mode = getLocalStorageDataFromKey("marketplace:albumArtBasedColorsMode");
+  // Add a hyphen before any uppercase characters
+  const modeStr = mode.replace(/([A-Z])/g, "-$1").toLowerCase();
+  const palette = await Spicetify.CosmosAsync.get(`https://www.thecolorapi.com/scheme?hex=${mainColor}&mode=${modeStr}&count=${numColors}`);
   // create an array of the hex values for the colors while also removing the #
   const colorArray = palette.colors.map((color) => color.hex.value.substring(1));
   return colorArray;

--- a/packages/marketplace/src/resources/locales/en-US.json
+++ b/packages/marketplace/src/resources/locales/en-US.json
@@ -1,7 +1,9 @@
 {
   "translation": {
     "settings": {
-      "colourShiftLabel": "Shift colors every minute"
+      "colourShiftLabel": "Shift colors every minute",
+      "albumArtBasedColors": "Change colors based on album art",
+      "albumArtBasedColorsMode": "The mode that the colorapi uses to generate color schemes"
     },
     "devTools": {
       "colorIniEditorPlaceholder": "[your-color-scheme-name]"

--- a/packages/marketplace/src/resources/locales/en.json
+++ b/packages/marketplace/src/resources/locales/en.json
@@ -9,6 +9,7 @@
       "hideInstalledLabel": "Hide installed when browsing",
       "colourShiftLabel": "Shift colours every minute",
       "albumArtBasedColors": "Change colours based on album art",
+      "albumArtBasedColorsMode": "The mode that the colorapi uses to generate color schemes",
       "tabsHeading": "Tabs",
       "resetHeading": "Reset",
       "resetBtn": "$t(settings.resetHeading)",

--- a/packages/marketplace/src/resources/locales/en.json
+++ b/packages/marketplace/src/resources/locales/en.json
@@ -8,6 +8,7 @@
       "devToolsLabel": "Theme developer tools",
       "hideInstalledLabel": "Hide installed when browsing",
       "colourShiftLabel": "Shift colours every minute",
+      "albumArtBasedColors": "Change colours based on album art",
       "tabsHeading": "Tabs",
       "resetHeading": "Reset",
       "resetBtn": "$t(settings.resetHeading)",

--- a/packages/marketplace/src/resources/locales/en.json
+++ b/packages/marketplace/src/resources/locales/en.json
@@ -9,7 +9,7 @@
       "hideInstalledLabel": "Hide installed when browsing",
       "colourShiftLabel": "Shift colours every minute",
       "albumArtBasedColors": "Change colours based on album art",
-      "albumArtBasedColorsMode": "The mode that the colorapi uses to generate color schemes",
+      "albumArtBasedColorsMode": "The mode that the colorapi uses to generate colour schemes",
       "tabsHeading": "Tabs",
       "resetHeading": "Reset",
       "resetBtn": "$t(settings.resetHeading)",

--- a/packages/marketplace/src/types/marketplace-types.d.ts
+++ b/packages/marketplace/src/types/marketplace-types.d.ts
@@ -118,6 +118,7 @@ export type VisualConfig = {
   colorShift: boolean;
   themeDevTools: boolean;
   albumArtBasedColors: boolean;
+  albumArtBasedColorsMode: "monochromeLight" | "monochromeDark" | "quad" | "triad" | "analogic"|"analogicComplement";
   // Legacy from reddit app
   type: boolean;
   // I was considering adding watchers as "followers" but it looks like the value is a duplicate

--- a/packages/marketplace/src/types/marketplace-types.d.ts
+++ b/packages/marketplace/src/types/marketplace-types.d.ts
@@ -1,3 +1,4 @@
+
 declare global {
   interface Window {
     Marketplace: Record<string, unknown>;
@@ -116,6 +117,7 @@ export type VisualConfig = {
   hideInstalled: boolean;
   colorShift: boolean;
   themeDevTools: boolean;
+  albumArtBasedColors: boolean;
   // Legacy from reddit app
   type: boolean;
   // I was considering adding watchers as "followers" but it looks like the value is a duplicate

--- a/packages/marketplace/src/types/marketplace-types.d.ts
+++ b/packages/marketplace/src/types/marketplace-types.d.ts
@@ -118,7 +118,7 @@ export type VisualConfig = {
   colorShift: boolean;
   themeDevTools: boolean;
   albumArtBasedColors: boolean;
-  albumArtBasedColorsMode: "monochromeLight" | "monochromeDark" | "quad" | "triad" | "analogic"|"analogicComplement";
+  albumArtBasedColorsMode: "monochromeLight" | "monochromeDark" | "quad" | "triad" | "analogic" | "analogicComplement";
   // Legacy from reddit app
   type: boolean;
   // I was considering adding watchers as "followers" but it looks like the value is a duplicate

--- a/yarn.lock
+++ b/yarn.lock
@@ -596,6 +596,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@spicetify/marketplace@workspace:packages/marketplace"
   dependencies:
+    "@types/chroma-js": ^2.1.4
     "@types/filesystem": ^0.0.32
     "@types/react": ^17.0.2
     "@types/react-dom": ^17.0.2
@@ -603,6 +604,7 @@ __metadata:
     "@types/wicg-file-system-access": ^2020.9.5
     "@typescript-eslint/eslint-plugin": ^5.45.0
     "@typescript-eslint/parser": ^5.45.0
+    chroma-js: ^2.4.2
     copyfiles: ^2.4.1
     eslint: ^8.28.0
     eslint-plugin-react: ^7.31.11
@@ -5748,8 +5750,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "spicetify-marketplace@workspace:."
   dependencies:
-    "@types/chroma-js": ^2.1.4
-    chroma-js: ^2.4.2
     husky: ^8.0.2
   languageName: unknown
   linkType: soft

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/polyfill@npm:^7.0.0":
+  version: 7.12.1
+  resolution: "@babel/polyfill@npm:7.12.1"
+  dependencies:
+    core-js: ^2.6.5
+    regenerator-runtime: ^0.13.4
+  checksum: 3f59a9d85a41b390b044a1be13e11ae6d8efbfcf4e07217964585c7cef337b828eecfc5e164083227189146d2b6efc1affae8f59c831438eb40b848ab6fe5f39
+  languageName: node
+  linkType: hard
+
 "@babel/runtime@npm:^7.14.5, @babel/runtime@npm:^7.17.2":
   version: 7.18.9
   resolution: "@babel/runtime@npm:7.18.9"
@@ -83,6 +93,372 @@ __metadata:
   version: 1.2.1
   resolution: "@humanwhocodes/object-schema@npm:1.2.1"
   checksum: a824a1ec31591231e4bad5787641f59e9633827d0a2eaae131a288d33c9ef0290bd16fda8da6f7c0fcb014147865d12118df10db57f27f41e20da92369fcb3f1
+  languageName: node
+  linkType: hard
+
+"@jimp/bmp@npm:^0.5.4":
+  version: 0.5.4
+  resolution: "@jimp/bmp@npm:0.5.4"
+  dependencies:
+    "@jimp/utils": ^0.5.0
+    bmp-js: ^0.1.0
+    core-js: ^2.5.7
+  peerDependencies:
+    "@jimp/custom": ">=0.3.5"
+  checksum: 39e00b0d3178292f37bc1959b1758d07aea8649a37218da7ad9e97100dc3c5802816ae22eb48c6f346395f51f5aef7c0ea0bf59dec306a3dcbce07dbbe6c16c4
+  languageName: node
+  linkType: hard
+
+"@jimp/core@npm:^0.5.4":
+  version: 0.5.4
+  resolution: "@jimp/core@npm:0.5.4"
+  dependencies:
+    "@jimp/utils": ^0.5.0
+    any-base: ^1.1.0
+    buffer: ^5.2.0
+    core-js: ^2.5.7
+    exif-parser: ^0.1.12
+    file-type: ^9.0.0
+    load-bmfont: ^1.3.1
+    mkdirp: 0.5.1
+    phin: ^2.9.1
+    pixelmatch: ^4.0.2
+    tinycolor2: ^1.4.1
+  checksum: 38ab41888c566cbb2514b6cc1a3c3197def3eb0f2c151af3c880ae95d34374856fb35b4ee57b203957f0ffe0e6a210ea9c87acada0e1af6b160919ab6fa599c9
+  languageName: node
+  linkType: hard
+
+"@jimp/custom@npm:^0.5.4":
+  version: 0.5.4
+  resolution: "@jimp/custom@npm:0.5.4"
+  dependencies:
+    "@jimp/core": ^0.5.4
+    core-js: ^2.5.7
+  checksum: 886bddc52e68bbfb9b1bdc58272b3b6fac1494045ac384d3a44dc157a978e6e665e94be962c922bd5f6b7c5815501c5c77fe88ed73b74ce53313e3852048e049
+  languageName: node
+  linkType: hard
+
+"@jimp/gif@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "@jimp/gif@npm:0.5.0"
+  dependencies:
+    "@jimp/utils": ^0.5.0
+    core-js: ^2.5.7
+    omggif: ^1.0.9
+  peerDependencies:
+    "@jimp/custom": ">=0.3.5"
+  checksum: 3ff32be14802fd5063e17b5d0909d28fe80fd0a59da1af1b1aa53db526965b7fec9f8c26835c07b73cced25fce6b5761594dd370780521c7a44f7dc53fd00c60
+  languageName: node
+  linkType: hard
+
+"@jimp/jpeg@npm:^0.5.4":
+  version: 0.5.4
+  resolution: "@jimp/jpeg@npm:0.5.4"
+  dependencies:
+    "@jimp/utils": ^0.5.0
+    core-js: ^2.5.7
+    jpeg-js: ^0.3.4
+  peerDependencies:
+    "@jimp/custom": ">=0.3.5"
+  checksum: dd84b001a25afe4e38df31e09992536a1e800090c637f11b9fdb353cd9cc704ee0498444ee71f4b02dcc60f64822bd6cf38c13fd37af2ed20f540a893afc24ed
+  languageName: node
+  linkType: hard
+
+"@jimp/plugin-blit@npm:^0.5.4":
+  version: 0.5.4
+  resolution: "@jimp/plugin-blit@npm:0.5.4"
+  dependencies:
+    "@jimp/utils": ^0.5.0
+    core-js: ^2.5.7
+  peerDependencies:
+    "@jimp/custom": ">=0.3.5"
+  checksum: 066a9608e5b8c0a6b0e297f3191658cd56bc05e644b97ee091ce15ce546276596e32582924f2a1c506f7f3035d3e9ef20af515af2bec164f85b932fcf8638a28
+  languageName: node
+  linkType: hard
+
+"@jimp/plugin-blur@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "@jimp/plugin-blur@npm:0.5.0"
+  dependencies:
+    "@jimp/utils": ^0.5.0
+    core-js: ^2.5.7
+  peerDependencies:
+    "@jimp/custom": ">=0.3.5"
+  checksum: f391cdd0784ab5eb3550dfc41745e8d8af1138252fc712f0df237e81552eb4f804404e51aea61bbafcee5c7b708fa31f4d39779aa2f9d1199a2e4029fee5fbd0
+  languageName: node
+  linkType: hard
+
+"@jimp/plugin-color@npm:^0.5.5":
+  version: 0.5.5
+  resolution: "@jimp/plugin-color@npm:0.5.5"
+  dependencies:
+    "@jimp/utils": ^0.5.0
+    core-js: ^2.5.7
+    tinycolor2: ^1.4.1
+  peerDependencies:
+    "@jimp/custom": ">=0.3.5"
+  checksum: 7044b275d92e06f784f80dd424e676d8979f4f4eeca0c2d19d8dd77c20cf791dac8415e6d50731a1b16e78d04696eb8f60da9a5ca15fe3fa2253b59d1752eda9
+  languageName: node
+  linkType: hard
+
+"@jimp/plugin-contain@npm:^0.5.4":
+  version: 0.5.4
+  resolution: "@jimp/plugin-contain@npm:0.5.4"
+  dependencies:
+    "@jimp/utils": ^0.5.0
+    core-js: ^2.5.7
+  peerDependencies:
+    "@jimp/custom": ">=0.3.5"
+    "@jimp/plugin-blit": ">=0.3.5"
+    "@jimp/plugin-resize": ">=0.3.5"
+    "@jimp/plugin-scale": ">=0.3.5"
+  checksum: 7faa0e7b78f7aadc1e4ce34345d62ee96382da91568322c256cab1d241a747e093432c6d44b1885a389b307449c8db9fdba9779a431e1d92edabdabd7b5ea983
+  languageName: node
+  linkType: hard
+
+"@jimp/plugin-cover@npm:^0.5.4":
+  version: 0.5.4
+  resolution: "@jimp/plugin-cover@npm:0.5.4"
+  dependencies:
+    "@jimp/utils": ^0.5.0
+    core-js: ^2.5.7
+  peerDependencies:
+    "@jimp/custom": ">=0.3.5"
+    "@jimp/plugin-crop": ">=0.3.5"
+    "@jimp/plugin-resize": ">=0.3.5"
+    "@jimp/plugin-scale": ">=0.3.5"
+  checksum: 96902c7e349eacd0ad34f9f4de0ca0c256e3ee3ce782be8fe9f4f786222998d171c29833deb984ac4a44c5375ebb6a860b31924d387566dbf06dd9ebcdf09e46
+  languageName: node
+  linkType: hard
+
+"@jimp/plugin-crop@npm:^0.5.4":
+  version: 0.5.4
+  resolution: "@jimp/plugin-crop@npm:0.5.4"
+  dependencies:
+    "@jimp/utils": ^0.5.0
+    core-js: ^2.5.7
+  peerDependencies:
+    "@jimp/custom": ">=0.3.5"
+  checksum: e849bd71eef47117640c08ec763f5b9a25748509767a4ad235d0e6fc802c3ece77fe26d947fcd3b77cefe2d5c753ab3dda9b10afd42da74152df2558c617cdb9
+  languageName: node
+  linkType: hard
+
+"@jimp/plugin-displace@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "@jimp/plugin-displace@npm:0.5.0"
+  dependencies:
+    "@jimp/utils": ^0.5.0
+    core-js: ^2.5.7
+  peerDependencies:
+    "@jimp/custom": ">=0.3.5"
+  checksum: efabf5d9787dc811c04a8b002b2f67f4d4d6c054fd0bd1bddb2cb9c92df9ccc32ef4c3a4df246e5e6fc7399d7c5217cf06c958f8c9fbf7839069035975bcd033
+  languageName: node
+  linkType: hard
+
+"@jimp/plugin-dither@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "@jimp/plugin-dither@npm:0.5.0"
+  dependencies:
+    "@jimp/utils": ^0.5.0
+    core-js: ^2.5.7
+  peerDependencies:
+    "@jimp/custom": ">=0.3.5"
+  checksum: fbc5731caefeccb918d5863c77245c6e8a30adf9951419a60324474605f51625d720e257df1dce324740155fe2ee9a487292efa93d7480fdbcc8b8fc30b60af0
+  languageName: node
+  linkType: hard
+
+"@jimp/plugin-flip@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "@jimp/plugin-flip@npm:0.5.0"
+  dependencies:
+    "@jimp/utils": ^0.5.0
+    core-js: ^2.5.7
+  peerDependencies:
+    "@jimp/custom": ">=0.3.5"
+    "@jimp/plugin-rotate": ">=0.3.5"
+  checksum: 3ae3d932dda831db7a93b3dc083441cd3a90cf2ac0641df9bfc7a1f67ed3352a8aae683f6def9cdecc4b18b827ed79aa0b9e65a79e580e4a6d57ccc12be7b0e5
+  languageName: node
+  linkType: hard
+
+"@jimp/plugin-gaussian@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "@jimp/plugin-gaussian@npm:0.5.0"
+  dependencies:
+    "@jimp/utils": ^0.5.0
+    core-js: ^2.5.7
+  peerDependencies:
+    "@jimp/custom": ">=0.3.5"
+  checksum: 062a05f6266c3a5e91837cd28e418a7621963a05a882bc1565fe03cb52031b64dcba3fba53c95f40588d9293ae28351cb83e88aae525c16c8983e119cf426fdd
+  languageName: node
+  linkType: hard
+
+"@jimp/plugin-invert@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "@jimp/plugin-invert@npm:0.5.0"
+  dependencies:
+    "@jimp/utils": ^0.5.0
+    core-js: ^2.5.7
+  peerDependencies:
+    "@jimp/custom": ">=0.3.5"
+  checksum: 451d16e2f360deed63c98ba1426f82b824c53aa31d5386262f67afc95a7f8b068bf0cc9ade985d0b2554b8027890d12e84840f6a1e9d6eaa65923fc149dfcc68
+  languageName: node
+  linkType: hard
+
+"@jimp/plugin-mask@npm:^0.5.4":
+  version: 0.5.4
+  resolution: "@jimp/plugin-mask@npm:0.5.4"
+  dependencies:
+    "@jimp/utils": ^0.5.0
+    core-js: ^2.5.7
+  peerDependencies:
+    "@jimp/custom": ">=0.3.5"
+  checksum: d71a311f1dcfc479aec696bb322404b0aef03edf33843a9f56beb76b6d13a62f18c0d7bc2a6bde74a4558ec1ab52e57238ea42369bcf2edb3eb8696f50135604
+  languageName: node
+  linkType: hard
+
+"@jimp/plugin-normalize@npm:^0.5.4":
+  version: 0.5.4
+  resolution: "@jimp/plugin-normalize@npm:0.5.4"
+  dependencies:
+    "@jimp/utils": ^0.5.0
+    core-js: ^2.5.7
+  peerDependencies:
+    "@jimp/custom": ">=0.3.5"
+  checksum: ac557b378c73d37915d135e541f525d8bbab2d71b595fc63a9c6f3535ea6523234b9a4422cd99c7d1d52af3971ca2030ce9343998e870c2b70b726548ef024f3
+  languageName: node
+  linkType: hard
+
+"@jimp/plugin-print@npm:^0.5.4":
+  version: 0.5.4
+  resolution: "@jimp/plugin-print@npm:0.5.4"
+  dependencies:
+    "@jimp/utils": ^0.5.0
+    core-js: ^2.5.7
+    load-bmfont: ^1.4.0
+  peerDependencies:
+    "@jimp/custom": ">=0.3.5"
+    "@jimp/plugin-blit": ">=0.3.5"
+  checksum: 03fcad1ade1fecce23e3e62cace9ce667f7cc47e9dfcd50c956b9cb99b9163e814e4846ab0ab58d73fb19caeff283dab75b6df2689e10d61fb9d5d521bbdd253
+  languageName: node
+  linkType: hard
+
+"@jimp/plugin-resize@npm:^0.5.4":
+  version: 0.5.4
+  resolution: "@jimp/plugin-resize@npm:0.5.4"
+  dependencies:
+    "@jimp/utils": ^0.5.0
+    core-js: ^2.5.7
+  peerDependencies:
+    "@jimp/custom": ">=0.3.5"
+  checksum: c160f93c37cafa23704b8045ea86d4a34b216f7d707bcf1e170a4f56aebe64c1be0cf83f20c3058d79d666f1933f1df74e98aa8bb16c8dc7d4af67a2e37989f0
+  languageName: node
+  linkType: hard
+
+"@jimp/plugin-rotate@npm:^0.5.4":
+  version: 0.5.4
+  resolution: "@jimp/plugin-rotate@npm:0.5.4"
+  dependencies:
+    "@jimp/utils": ^0.5.0
+    core-js: ^2.5.7
+  peerDependencies:
+    "@jimp/custom": ">=0.3.5"
+    "@jimp/plugin-blit": ">=0.3.5"
+    "@jimp/plugin-crop": ">=0.3.5"
+    "@jimp/plugin-resize": ">=0.3.5"
+  checksum: 1f8b78e93ed1243a1852311186df1d470bbc762d17fd99934923d3bee8d4f79cc0067eb99e060d92dcdda60cb1f8332fd624dee04a9e07e80e9187d8d449f28c
+  languageName: node
+  linkType: hard
+
+"@jimp/plugin-scale@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "@jimp/plugin-scale@npm:0.5.0"
+  dependencies:
+    "@jimp/utils": ^0.5.0
+    core-js: ^2.5.7
+  peerDependencies:
+    "@jimp/custom": ">=0.3.5"
+    "@jimp/plugin-resize": ">=0.3.5"
+  checksum: a954c65c09d93bdfb1e7127efcff53f7ebc9c61b2d2a71855b5a45e0e5a17c579b42413651d69369e35eb6a00a5d874fc5b2c0a2a8446df95fae6b5f1198722a
+  languageName: node
+  linkType: hard
+
+"@jimp/plugins@npm:^0.5.5":
+  version: 0.5.5
+  resolution: "@jimp/plugins@npm:0.5.5"
+  dependencies:
+    "@jimp/plugin-blit": ^0.5.4
+    "@jimp/plugin-blur": ^0.5.0
+    "@jimp/plugin-color": ^0.5.5
+    "@jimp/plugin-contain": ^0.5.4
+    "@jimp/plugin-cover": ^0.5.4
+    "@jimp/plugin-crop": ^0.5.4
+    "@jimp/plugin-displace": ^0.5.0
+    "@jimp/plugin-dither": ^0.5.0
+    "@jimp/plugin-flip": ^0.5.0
+    "@jimp/plugin-gaussian": ^0.5.0
+    "@jimp/plugin-invert": ^0.5.0
+    "@jimp/plugin-mask": ^0.5.4
+    "@jimp/plugin-normalize": ^0.5.4
+    "@jimp/plugin-print": ^0.5.4
+    "@jimp/plugin-resize": ^0.5.4
+    "@jimp/plugin-rotate": ^0.5.4
+    "@jimp/plugin-scale": ^0.5.0
+    core-js: ^2.5.7
+    timm: ^1.6.1
+  peerDependencies:
+    "@jimp/custom": ">=0.3.5"
+  checksum: c1a7c5f5acd66b9d817d0a729378572f150e737b9ed81176739e42eb6df1ac160c09e74485d8cae9f1abf99d9fdc7b4dfb13109283e79c1c19dd21abbd581cd8
+  languageName: node
+  linkType: hard
+
+"@jimp/png@npm:^0.5.4":
+  version: 0.5.4
+  resolution: "@jimp/png@npm:0.5.4"
+  dependencies:
+    "@jimp/utils": ^0.5.0
+    core-js: ^2.5.7
+    pngjs: ^3.3.3
+  peerDependencies:
+    "@jimp/custom": ">=0.3.5"
+  checksum: 3f63235da353b1dbfc033d2053a8bfdc1a5ab2602bd3dc3f23f27d6cb8d1938406aa040ae3f885e95196d0b695cf699ec0dc8c62bc8b7aefeff45c3eadbd62c3
+  languageName: node
+  linkType: hard
+
+"@jimp/tiff@npm:^0.5.4":
+  version: 0.5.4
+  resolution: "@jimp/tiff@npm:0.5.4"
+  dependencies:
+    core-js: ^2.5.7
+    utif: ^2.0.1
+  peerDependencies:
+    "@jimp/custom": ">=0.3.5"
+  checksum: 6979ce115552c6a2ca42d66dd83f260e3b5fdb99d994201a1c235fae7bc2c4be9f3ed9c7e71dba4bd9cf70b2792561fd7ea7557ed2e2b3bacaa1e110f40d3075
+  languageName: node
+  linkType: hard
+
+"@jimp/types@npm:^0.5.4":
+  version: 0.5.4
+  resolution: "@jimp/types@npm:0.5.4"
+  dependencies:
+    "@jimp/bmp": ^0.5.4
+    "@jimp/gif": ^0.5.0
+    "@jimp/jpeg": ^0.5.4
+    "@jimp/png": ^0.5.4
+    "@jimp/tiff": ^0.5.4
+    core-js: ^2.5.7
+    timm: ^1.6.1
+  peerDependencies:
+    "@jimp/custom": ">=0.3.5"
+  checksum: de022d23fd64fe2b4ee47bb4bc318f33b91575f0c6200b2de6da6ed2d5812828d7715ab20e2432406b9e2ea757e6d69257344f35d6c07333541aaaa7e380b95c
+  languageName: node
+  linkType: hard
+
+"@jimp/utils@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "@jimp/utils@npm:0.5.0"
+  dependencies:
+    core-js: ^2.5.7
+  checksum: 491d250ee849eff4e7cc617fa4199fbfb5e360a2c62b0c3e51c3ad4cb87755853342d7d95c37e8a0f7aa95238f1e572f73bdfdecce49bf64ffce53dd1d67c8b9
   languageName: node
   linkType: hard
 
@@ -232,6 +608,7 @@ __metadata:
     eslint-plugin-react: ^7.31.11
     i18next: ^22.0.6
     i18next-browser-languagedetector: ^7.0.1
+    node-vibrant: 3.1.4
     prismjs: ^1.29.0
     react-dropdown: ^1.11.0
     react-i18next: ^12.0.0
@@ -257,6 +634,13 @@ __metadata:
     "@types/connect": "*"
     "@types/node": "*"
   checksum: e17840c7d747a549f00aebe72c89313d09fbc4b632b949b2470c5cb3b1cb73863901ae84d9335b567a79ec5efcfb8a28ff8e3f36bc8748a9686756b6d5681f40
+  languageName: node
+  linkType: hard
+
+"@types/chroma-js@npm:^2.1.4":
+  version: 2.1.4
+  resolution: "@types/chroma-js@npm:2.1.4"
+  checksum: 24f1a1dd1c7b21548299c320bfa01e6407acb70193e567af16c28f742571fe56bb1eea0aedc41281478a175c70772a4627d5a9bf5b9cd854a7b455c38a3a5645
   languageName: node
   linkType: hard
 
@@ -351,6 +735,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/lodash@npm:^4.14.53":
+  version: 4.14.191
+  resolution: "@types/lodash@npm:4.14.191"
+  checksum: ba0d5434e10690869f32d5ea49095250157cae502f10d57de0a723fd72229ce6c6a4979576f0f13e0aa9fbe3ce2457bfb9fa7d4ec3d6daba56730a51906d1491
+  languageName: node
+  linkType: hard
+
 "@types/mime@npm:*":
   version: 3.0.1
   resolution: "@types/mime@npm:3.0.1"
@@ -387,6 +778,13 @@ __metadata:
   version: 18.7.14
   resolution: "@types/node@npm:18.7.14"
   checksum: 99cf28ff854100158de875cca23c7acc3cc01dfee526a52b90b7f36767c821bcbaf2be0a98a70f06f3b78f3c60639168ff949d725b61e2e124f9f71f1fb8043d
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^10.11.7":
+  version: 10.17.60
+  resolution: "@types/node@npm:10.17.60"
+  checksum: 2cdb3a77d071ba8513e5e8306fa64bf50e3c3302390feeaeff1fd325dd25c8441369715dfc8e3701011a72fed5958c7dfa94eb9239a81b3c286caa4d97db6eef
   languageName: node
   linkType: hard
 
@@ -698,6 +1096,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"any-base@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "any-base@npm:1.1.0"
+  checksum: c1fd040de52e710e2de7d9ae4df52bac589f35622adb24686c98ce21c7b824859a8db9614bc119ed8614f42fd08918b2612e6a6c385480462b3100a1af59289d
+  languageName: node
+  linkType: hard
+
 "anymatch@npm:~3.1.2":
   version: 3.1.2
   resolution: "anymatch@npm:3.1.2"
@@ -889,6 +1294,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"base64-js@npm:^1.3.1":
+  version: 1.5.1
+  resolution: "base64-js@npm:1.5.1"
+  checksum: 669632eb3745404c2f822a18fc3a0122d2f9a7a13f7fb8b5823ee19d1d2ff9ee5b52c53367176ea4ad093c332fd5ab4bd0ebae5a8e27917a4105a4cfc86b1005
+  languageName: node
+  linkType: hard
+
 "base@npm:^0.11.1":
   version: 0.11.2
   resolution: "base@npm:0.11.2"
@@ -908,6 +1320,13 @@ __metadata:
   version: 2.2.0
   resolution: "binary-extensions@npm:2.2.0"
   checksum: ccd267956c58d2315f5d3ea6757cf09863c5fc703e50fbeb13a7dc849b812ef76e3cf9ca8f35a0c48498776a7478d7b4a0418e1e2b8cb9cb9731f2922aaad7f8
+  languageName: node
+  linkType: hard
+
+"bmp-js@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "bmp-js@npm:0.1.0"
+  checksum: 2f6cf7eeabae2aa50eb768122f59e9752caa97248028cb8b5cf0d9db7cf8fb3a60262aeb2c6889dd21357ab061b2fb318f21f20d2b24963ba36ead8e264c6654
   languageName: node
   linkType: hard
 
@@ -991,10 +1410,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"buffer-equal@npm:0.0.1":
+  version: 0.0.1
+  resolution: "buffer-equal@npm:0.0.1"
+  checksum: ca4b52e6c01143529d957a78cb9a93e4257f172bbab30d9eb87c20ae085ed23c5e07f236ac051202dacbf3d17aba42e1455f84cba21ea79b67d57f2b05e9a613
+  languageName: node
+  linkType: hard
+
 "buffer-from@npm:^1.0.0":
   version: 1.1.2
   resolution: "buffer-from@npm:1.1.2"
   checksum: 0448524a562b37d4d7ed9efd91685a5b77a50672c556ea254ac9a6d30e3403a517d8981f10e565db24e8339413b43c97ca2951f10e399c6125a0d8911f5679bb
+  languageName: node
+  linkType: hard
+
+"buffer@npm:^5.2.0":
+  version: 5.7.1
+  resolution: "buffer@npm:5.7.1"
+  dependencies:
+    base64-js: ^1.3.1
+    ieee754: ^1.1.13
+  checksum: e2cf8429e1c4c7b8cbd30834ac09bd61da46ce35f5c22a78e6c2f04497d6d25541b16881e30a019c6fd3154150650ccee27a308eff3e26229d788bbdeb08ab84
   languageName: node
   linkType: hard
 
@@ -1112,6 +1548,13 @@ __metadata:
   version: 2.0.0
   resolution: "chownr@npm:2.0.0"
   checksum: c57cf9dd0791e2f18a5ee9c1a299ae6e801ff58fee96dc8bfd0dcb4738a6ce58dd252a3605b1c93c6418fe4f9d5093b28ffbf4d66648cb2a9c67eaef9679be2f
+  languageName: node
+  linkType: hard
+
+"chroma-js@npm:^2.4.2":
+  version: 2.4.2
+  resolution: "chroma-js@npm:2.4.2"
+  checksum: cf9884c02d406286e4370599bcd1afbf089384407df46b3a69edfedcba7bb99e8f959a5cfdbfec750b305c441c06ca40cd1f70ba3a6c2ce739ac09a92520ddae
   languageName: node
   linkType: hard
 
@@ -1285,6 +1728,13 @@ __metadata:
     copyfiles: copyfiles
     copyup: copyfiles
   checksum: aea69873bb99cc5f553967660cbfb70e4eeda198f572a36fb0f748b36877ff2c90fd906c58b1d540adbad8afa8ee82820172f1c18e69736f7ab52792c12745a7
+  languageName: node
+  linkType: hard
+
+"core-js@npm:^2.5.7, core-js@npm:^2.6.5":
+  version: 2.6.12
+  resolution: "core-js@npm:2.6.12"
+  checksum: 44fa9934a85f8c78d61e0c8b7b22436330471ffe59ec5076fe7f324d6e8cf7f824b14b1c81ca73608b13bdb0fef035bd820989bf059767ad6fa13123bb8bd016
   languageName: node
   linkType: hard
 
@@ -1475,6 +1925,13 @@ __metadata:
   dependencies:
     esutils: ^2.0.2
   checksum: fd7673ca77fe26cd5cba38d816bc72d641f500f1f9b25b83e8ce28827fe2da7ad583a8da26ab6af85f834138cf8dae9f69b0cd6ab925f52ddab1754db44d99ce
+  languageName: node
+  linkType: hard
+
+"dom-walk@npm:^0.1.0":
+  version: 0.1.2
+  resolution: "dom-walk@npm:0.1.2"
+  checksum: 19eb0ce9c6de39d5e231530685248545d9cd2bd97b2cb3486e0bfc0f2a393a9addddfd5557463a932b52fdfcf68ad2a619020cd2c74a5fe46fbecaa8e80872f3
   languageName: node
   linkType: hard
 
@@ -2063,6 +2520,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"exif-parser@npm:^0.1.12":
+  version: 0.1.12
+  resolution: "exif-parser@npm:0.1.12"
+  checksum: 6ba50cb9e0b45a6efa37e966a9582ecd171b5c5b3ef0c47542f2b862c521f70d2f656dde85b4d2a5dd8e1163486b09049f4c412e9c6176bfbda1654a5b2f021c
+  languageName: node
+  linkType: hard
+
 "expand-brackets@npm:^2.1.4":
   version: 2.1.4
   resolution: "expand-brackets@npm:2.1.4"
@@ -2233,6 +2697,13 @@ __metadata:
   dependencies:
     flat-cache: ^3.0.4
   checksum: f49701feaa6314c8127c3c2f6173cfefff17612f5ed2daaafc6da13b5c91fd43e3b2a58fd0d63f9f94478a501b167615931e7200e31485e320f74a33885a9c74
+  languageName: node
+  linkType: hard
+
+"file-type@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "file-type@npm:9.0.0"
+  checksum: 9ea78b29c3762d967eb1e3e4f45e401388b6d252b12c217f78f5ea97556ff7e35e4c7255cab68810ac414d51b776bd4e83504c86f132c262a454251561189efa
   languageName: node
   linkType: hard
 
@@ -2590,6 +3061,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"global@npm:~4.4.0":
+  version: 4.4.0
+  resolution: "global@npm:4.4.0"
+  dependencies:
+    min-document: ^2.19.0
+    process: ^0.11.10
+  checksum: 9c057557c8f5a5bcfbeb9378ba4fe2255d04679452be504608dd5f13b54edf79f7be1db1031ea06a4ec6edd3b9f5f17d2d172fb47e6c69dae57fd84b7e72b77f
+  languageName: node
+  linkType: hard
+
 "globals@npm:^13.15.0":
   version: 13.17.0
   resolution: "globals@npm:13.17.0"
@@ -2866,6 +3347,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ieee754@npm:^1.1.13":
+  version: 1.2.1
+  resolution: "ieee754@npm:1.2.1"
+  checksum: 5144c0c9815e54ada181d80a0b810221a253562422e7c6c3a60b1901154184f49326ec239d618c416c1c5945a2e197107aee8d986a3dd836b53dffefd99b5e7e
+  languageName: node
+  linkType: hard
+
 "ignore@npm:^4.0.3":
   version: 4.0.6
   resolution: "ignore@npm:4.0.6"
@@ -3131,6 +3619,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-function@npm:^1.0.1":
+  version: 1.0.2
+  resolution: "is-function@npm:1.0.2"
+  checksum: 7d564562e07b4b51359547d3ccc10fb93bb392fd1b8177ae2601ee4982a0ece86d952323fc172a9000743a3971f09689495ab78a1d49a9b14fc97a7e28521dc0
+  languageName: node
+  linkType: hard
+
 "is-glob@npm:^3.1.0":
   version: 3.1.0
   resolution: "is-glob@npm:3.1.0"
@@ -3308,6 +3803,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jimp@npm:^0.5.4":
+  version: 0.5.6
+  resolution: "jimp@npm:0.5.6"
+  dependencies:
+    "@babel/polyfill": ^7.0.0
+    "@jimp/custom": ^0.5.4
+    "@jimp/plugins": ^0.5.5
+    "@jimp/types": ^0.5.4
+    core-js: ^2.5.7
+  checksum: 82bd2ffd39adcca12f52c66a7dab74c36cb2a626f3d0b29fdef3347b875deb7b1c6933ef8d15dafb8918a9833d43830abb1c105239af6784f12ce3a9b6f9fe89
+  languageName: node
+  linkType: hard
+
+"jpeg-js@npm:^0.3.4":
+  version: 0.3.7
+  resolution: "jpeg-js@npm:0.3.7"
+  checksum: 85a1ab09fe696fdd7b94ee077f1b8d1de307ffd7a83c0c45cc5cc56b0d7b47e561b92f6f090165648387875d674ba3076e3fedf395d5be4ef46760b6ebc804fe
+  languageName: node
+  linkType: hard
+
 "js-sdsl@npm:^4.1.4":
   version: 4.1.4
   resolution: "js-sdsl@npm:4.1.4"
@@ -3456,6 +3971,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"load-bmfont@npm:^1.3.1, load-bmfont@npm:^1.4.0":
+  version: 1.4.1
+  resolution: "load-bmfont@npm:1.4.1"
+  dependencies:
+    buffer-equal: 0.0.1
+    mime: ^1.3.4
+    parse-bmfont-ascii: ^1.0.3
+    parse-bmfont-binary: ^1.0.5
+    parse-bmfont-xml: ^1.1.4
+    phin: ^2.9.1
+    xhr: ^2.0.1
+    xtend: ^4.0.0
+  checksum: 688d932fb0dc4c9333747736ccd926261f0b91734b7bdb6ff24f8659ef068a0f0b2278084b208851afac0beec79af7bd6664fe2ed5b6c5e1db88755fc25f785e
+  languageName: node
+  linkType: hard
+
 "loader-utils@npm:^3.2.0":
   version: 3.2.1
   resolution: "loader-utils@npm:3.2.1"
@@ -3483,6 +4014,13 @@ __metadata:
   version: 4.6.2
   resolution: "lodash.merge@npm:4.6.2"
   checksum: ad580b4bdbb7ca1f7abf7e1bce63a9a0b98e370cf40194b03380a46b4ed799c9573029599caebc1b14e3f24b111aef72b96674a56cfa105e0f5ac70546cdc005
+  languageName: node
+  linkType: hard
+
+"lodash@npm:^4.17.4":
+  version: 4.17.21
+  resolution: "lodash@npm:4.17.21"
+  checksum: eb835a2e51d381e561e508ce932ea50a8e5a68f4ebdd771ea240d3048244a8d13658acbd502cd4829768c56f2e16bdd4340b9ea141297d472517b83868e677f7
   languageName: node
   linkType: hard
 
@@ -3638,12 +4176,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime@npm:1.6.0, mime@npm:^1.4.1":
+"mime@npm:1.6.0, mime@npm:^1.3.4, mime@npm:^1.4.1":
   version: 1.6.0
   resolution: "mime@npm:1.6.0"
   bin:
     mime: cli.js
   checksum: fef25e39263e6d207580bdc629f8872a3f9772c923c7f8c7e793175cee22777bbe8bba95e5d509a40aaa292d8974514ce634ae35769faa45f22d17edda5e8557
+  languageName: node
+  linkType: hard
+
+"min-document@npm:^2.19.0":
+  version: 2.19.0
+  resolution: "min-document@npm:2.19.0"
+  dependencies:
+    dom-walk: ^0.1.0
+  checksum: da6437562ea2228041542a2384528e74e22d1daa1a4ec439c165abf0b9d8a63e17e3b8a6dc6e0c731845e85301198730426932a0e813d23f932ca668340c9623
   languageName: node
   linkType: hard
 
@@ -3662,6 +4209,13 @@ __metadata:
   dependencies:
     brace-expansion: ^2.0.1
   checksum: 15ce53d31a06361e8b7a629501b5c75491bc2b59712d53e802b1987121d91b433d73fcc5be92974fde66b2b51d8fb28d75a9ae900d249feb792bb1ba2a4f0a90
+  languageName: node
+  linkType: hard
+
+"minimist@npm:0.0.8":
+  version: 0.0.8
+  resolution: "minimist@npm:0.0.8"
+  checksum: 042f8b626b1fa44dffc23bac55771425ac4ee9d267b56f9064c07713e516e1799f3ba933bb628d2475a210caf7dcdb98161611baa1f0daf49309a944cb4bc48f
   languageName: node
   linkType: hard
 
@@ -3749,6 +4303,17 @@ __metadata:
     for-in: ^1.0.2
     is-extendable: ^1.0.1
   checksum: 820d5a51fcb7479f2926b97f2c3bb223546bc915e6b3a3eb5d906dda871bba569863595424a76682f2b15718252954644f3891437cb7e3f220949bed54b1750d
+  languageName: node
+  linkType: hard
+
+"mkdirp@npm:0.5.1":
+  version: 0.5.1
+  resolution: "mkdirp@npm:0.5.1"
+  dependencies:
+    minimist: 0.0.8
+  bin:
+    mkdirp: bin/cmd.js
+  checksum: ed1ab49bb1d06c88dba7cfe930a3186f2605b5465aab7c8f24119baaba6e38f9ab4ac1695c68f476c65a48df2a69a8495049cd6e26c360ea082151a0771343d2
   languageName: node
   linkType: hard
 
@@ -3868,6 +4433,19 @@ __metadata:
   version: 2.0.6
   resolution: "node-releases@npm:2.0.6"
   checksum: e86a926dc9fbb3b41b4c4a89d998afdf140e20a4e8dbe6c0a807f7b2948b42ea97d7fd3ad4868041487b6e9ee98409829c6e4d84a734a4215dff060a7fbeb4bf
+  languageName: node
+  linkType: hard
+
+"node-vibrant@npm:3.1.4":
+  version: 3.1.4
+  resolution: "node-vibrant@npm:3.1.4"
+  dependencies:
+    "@types/lodash": ^4.14.53
+    "@types/node": ^10.11.7
+    jimp: ^0.5.4
+    lodash: ^4.17.4
+    url: ^0.11.0
+  checksum: 0653b94b86be844e4b05893baf3f3c25600f8644e118f10d2d044769de577ba1d456e8f7eb2c937906eac55ff8d6fbeeee87fa652dfd05ec02e49e3e5728e224
   languageName: node
   linkType: hard
 
@@ -4023,6 +4601,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"omggif@npm:^1.0.9":
+  version: 1.0.10
+  resolution: "omggif@npm:1.0.10"
+  checksum: 15102e46b6fa0fba32d7e948f702623cdc3cdcdfd64b2d33c6e29a61f366ffd0f250da55d66f5217dce5b93ba9c67763fa998652791a5c7f2201a3bde2c4db45
+  languageName: node
+  linkType: hard
+
 "on-finished@npm:2.4.1":
   version: 2.4.1
   resolution: "on-finished@npm:2.4.1"
@@ -4089,12 +4674,50 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pako@npm:^1.0.5":
+  version: 1.0.11
+  resolution: "pako@npm:1.0.11"
+  checksum: 1be2bfa1f807608c7538afa15d6f25baa523c30ec870a3228a89579e474a4d992f4293859524e46d5d87fd30fa17c5edf34dbef0671251d9749820b488660b16
+  languageName: node
+  linkType: hard
+
 "parent-module@npm:^1.0.0":
   version: 1.0.1
   resolution: "parent-module@npm:1.0.1"
   dependencies:
     callsites: ^3.0.0
   checksum: 6ba8b255145cae9470cf5551eb74be2d22281587af787a2626683a6c20fbb464978784661478dd2a3f1dad74d1e802d403e1b03c1a31fab310259eec8ac560ff
+  languageName: node
+  linkType: hard
+
+"parse-bmfont-ascii@npm:^1.0.3":
+  version: 1.0.6
+  resolution: "parse-bmfont-ascii@npm:1.0.6"
+  checksum: de3f6671f183c3e9d64bb4812b0407693b5fd0d24e9d16b2e106bb9eef809d64a6cc061f39ca29bb10c5c2e47e241e91b7aeefa587391fff7ccb27ab9db5012e
+  languageName: node
+  linkType: hard
+
+"parse-bmfont-binary@npm:^1.0.5":
+  version: 1.0.6
+  resolution: "parse-bmfont-binary@npm:1.0.6"
+  checksum: ca37fb1e92f5941fddc5342b45857fafd27f00d2bd5fa44dd504bec6faeab97536c95ad45260c2dd5fc4c63de71e525663d3cdac09d038cbca803d97c669add5
+  languageName: node
+  linkType: hard
+
+"parse-bmfont-xml@npm:^1.1.4":
+  version: 1.1.4
+  resolution: "parse-bmfont-xml@npm:1.1.4"
+  dependencies:
+    xml-parse-from-string: ^1.0.0
+    xml2js: ^0.4.5
+  checksum: 879e5435be44f22b8c4934e2e1d2754a6d90a9ddb16309360daff965e1428d877b673f3d1fafaab4fef437c912a0db9f85545e0dd375ec62df7d4d328450d257
+  languageName: node
+  linkType: hard
+
+"parse-headers@npm:^2.0.0":
+  version: 2.0.5
+  resolution: "parse-headers@npm:2.0.5"
+  checksum: 3e97f01e4c7f960bfbfd0ee489f0bd8d3c72b6c814f1f79b66abec2cca8eaf8e4ecd89deba0b6e61266469aed87350bc932001181c01ff8c29a59e696abe251f
   languageName: node
   linkType: hard
 
@@ -4184,6 +4807,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"phin@npm:^2.9.1":
+  version: 2.9.3
+  resolution: "phin@npm:2.9.3"
+  checksum: 7e2abd7be74a54eb7be92dccb1d7a019725c8adaa79ac22a38f25220f9a859393e654ea753a559d326aed7bbc966fadac88270cc8c39d78896f7784219560c47
+  languageName: node
+  linkType: hard
+
 "picocolors@npm:^1.0.0":
   version: 1.0.0
   resolution: "picocolors@npm:1.0.0"
@@ -4209,6 +4839,24 @@ __metadata:
   version: 4.0.1
   resolution: "pify@npm:4.0.1"
   checksum: 9c4e34278cb09987685fa5ef81499c82546c033713518f6441778fbec623fc708777fe8ac633097c72d88470d5963094076c7305cafc7ad340aae27cfacd856b
+  languageName: node
+  linkType: hard
+
+"pixelmatch@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "pixelmatch@npm:4.0.2"
+  dependencies:
+    pngjs: ^3.0.0
+  bin:
+    pixelmatch: bin/pixelmatch
+  checksum: 9c5c1329001938cae6d01e2bb84a909ba767f8256bcafc075422cea2a4dbaa8bebd44fceaa4b4ce7cdc36d11f20d4f1ba0cf669851d5649b32d8d1d27e4f5a36
+  languageName: node
+  linkType: hard
+
+"pngjs@npm:^3.0.0, pngjs@npm:^3.3.3":
+  version: 3.4.0
+  resolution: "pngjs@npm:3.4.0"
+  checksum: 8bd40bd698abd16b72c97b85cb858c80894fbedc76277ce72a784aa441e14795d45d9856e97333ca469b34b67528860ffc8a7317ca6beea349b645366df00bcd
   languageName: node
   linkType: hard
 
@@ -4330,6 +4978,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"process@npm:^0.11.10":
+  version: 0.11.10
+  resolution: "process@npm:0.11.10"
+  checksum: bfcce49814f7d172a6e6a14d5fa3ac92cc3d0c3b9feb1279774708a719e19acd673995226351a082a9ae99978254e320ccda4240ddc474ba31a76c79491ca7c3
+  languageName: node
+  linkType: hard
+
 "promise-inflight@npm:^1.0.1":
   version: 1.0.1
   resolution: "promise-inflight@npm:1.0.1"
@@ -4375,6 +5030,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"punycode@npm:1.3.2":
+  version: 1.3.2
+  resolution: "punycode@npm:1.3.2"
+  checksum: b8807fd594b1db33335692d1f03e8beeddde6fda7fbb4a2e32925d88d20a3aa4cd8dcc0c109ccaccbd2ba761c208dfaaada83007087ea8bfb0129c9ef1b99ed6
+  languageName: node
+  linkType: hard
+
 "punycode@npm:^2.1.0":
   version: 2.1.1
   resolution: "punycode@npm:2.1.1"
@@ -4388,6 +5050,13 @@ __metadata:
   dependencies:
     side-channel: ^1.0.4
   checksum: 6e1f29dd5385f7488ec74ac7b6c92f4d09a90408882d0c208414a34dd33badc1a621019d4c799a3df15ab9b1d0292f97c1dd71dc7c045e69f81a8064e5af7297
+  languageName: node
+  linkType: hard
+
+"querystring@npm:0.2.0":
+  version: 0.2.0
+  resolution: "querystring@npm:0.2.0"
+  checksum: 8258d6734f19be27e93f601758858c299bdebe71147909e367101ba459b95446fbe5b975bf9beb76390156a592b6f4ac3a68b6087cea165c259705b8b4e56a69
   languageName: node
   linkType: hard
 
@@ -4760,7 +5429,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sax@npm:^1.2.4, sax@npm:~1.2.4":
+"sax@npm:>=0.6.0, sax@npm:^1.2.4, sax@npm:~1.2.4":
   version: 1.2.4
   resolution: "sax@npm:1.2.4"
   checksum: d3df7d32b897a2c2f28e941f732c71ba90e27c24f62ee918bd4d9a8cfb3553f2f81e5493c7f0be94a11c1911b643a9108f231dd6f60df3fa9586b5d2e3e9e1fe
@@ -5079,6 +5748,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "spicetify-marketplace@workspace:."
   dependencies:
+    "@types/chroma-js": ^2.1.4
+    chroma-js: ^2.4.2
     husky: ^8.0.2
   languageName: unknown
   linkType: soft
@@ -5288,6 +5959,20 @@ __metadata:
     readable-stream: ~2.3.6
     xtend: ~4.0.1
   checksum: beb0f338aa2931e5660ec7bf3ad949e6d2e068c31f4737b9525e5201b824ac40cac6a337224856b56bd1ddd866334bbfb92a9f57cd6f66bc3f18d3d86fc0fe50
+  languageName: node
+  linkType: hard
+
+"timm@npm:^1.6.1":
+  version: 1.7.1
+  resolution: "timm@npm:1.7.1"
+  checksum: c80df538ec7fae50a0e3183931b20fbe97f6f2c06907d9675eb7b9d90b3f788af7742285c730192db3b066c4ab22ebae75f8d21970c5b03f38d928d5bb2a0339
+  languageName: node
+  linkType: hard
+
+"tinycolor2@npm:^1.4.1":
+  version: 1.4.2
+  resolution: "tinycolor2@npm:1.4.2"
+  checksum: 57ed262e08815a4ab0ed933edafdbc6555a17081781766149813b44a080ecbe58b3ee281e81c0e75b42e4d41679f138cfa98eabf043f829e0683c04adb12c031
   languageName: node
   linkType: hard
 
@@ -5542,10 +6227,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"url@npm:^0.11.0":
+  version: 0.11.0
+  resolution: "url@npm:0.11.0"
+  dependencies:
+    punycode: 1.3.2
+    querystring: 0.2.0
+  checksum: 50d100d3dd2d98b9fe3ada48cadb0b08aa6be6d3ac64112b867b56b19be4bfcba03c2a9a0d7922bfd7ac17d4834e88537749fe182430dfd9b68e520175900d90
+  languageName: node
+  linkType: hard
+
 "use@npm:^3.1.0":
   version: 3.1.1
   resolution: "use@npm:3.1.1"
   checksum: 08a130289f5238fcbf8f59a18951286a6e660d17acccc9d58d9b69dfa0ee19aa038e8f95721b00b432c36d1629a9e32a464bf2e7e0ae6a244c42ddb30bdd8b33
+  languageName: node
+  linkType: hard
+
+"utif@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "utif@npm:2.0.1"
+  dependencies:
+    pako: ^1.0.5
+  checksum: 66b0bffc18f08834a34c44846f189b2223418e8bddfff3882e07fccea54436737f7334e27c86cbff46e247487dc92377b7a17428a7aafc5d5c733d61bed39038
   languageName: node
   linkType: hard
 
@@ -5646,7 +6350,43 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xtend@npm:~4.0.1":
+"xhr@npm:^2.0.1":
+  version: 2.6.0
+  resolution: "xhr@npm:2.6.0"
+  dependencies:
+    global: ~4.4.0
+    is-function: ^1.0.1
+    parse-headers: ^2.0.0
+    xtend: ^4.0.0
+  checksum: a1db277e37737caf3ed363d2a33ce4b4ea5b5fc190b663a6f70bc252799185b840ccaa166eaeeea4841c9c60b87741f0a24e29cbcf6708dd425986d4df186d2f
+  languageName: node
+  linkType: hard
+
+"xml-parse-from-string@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "xml-parse-from-string@npm:1.0.1"
+  checksum: 5155cb98e428409829f4060ce542c55438b2f7646d11fd306d850eaf12d35c06ffd9e86d76aa5230121a533b958fd1a319d6f90a5c113391853d0ff01f4da7bb
+  languageName: node
+  linkType: hard
+
+"xml2js@npm:^0.4.5":
+  version: 0.4.23
+  resolution: "xml2js@npm:0.4.23"
+  dependencies:
+    sax: ">=0.6.0"
+    xmlbuilder: ~11.0.0
+  checksum: ca0cf2dfbf6deeaae878a891c8fbc0db6fd04398087084edf143cdc83d0509ad0fe199b890f62f39c4415cf60268a27a6aed0d343f0658f8779bd7add690fa98
+  languageName: node
+  linkType: hard
+
+"xmlbuilder@npm:~11.0.0":
+  version: 11.0.1
+  resolution: "xmlbuilder@npm:11.0.1"
+  checksum: 7152695e16f1a9976658215abab27e55d08b1b97bca901d58b048d2b6e106b5af31efccbdecf9b07af37c8377d8e7e821b494af10b3a68b0ff4ae60331b415b0
+  languageName: node
+  linkType: hard
+
+"xtend@npm:^4.0.0, xtend@npm:~4.0.1":
   version: 4.0.2
   resolution: "xtend@npm:4.0.2"
   checksum: ac5dfa738b21f6e7f0dd6e65e1b3155036d68104e67e5d5d1bde74892e327d7e5636a076f625599dc394330a731861e87343ff184b0047fef1360a7ec0a5a36a


### PR DESCRIPTION
Going to edit the title before we merge, just thought it'd be funny.

This code isn't as clean as it can be of course, which is what I assume the review process will help with, however it does work.

New libraries/ api's used
When the song changes, it will get the main color of the album art using **node vibrant**,
it will then generate a scheme using **thecolorapi**
and the final library used is **chroma**, in order to sort the scheme the user actively has installed by the amount of contrast between each color 

To elaborate on some things, the reason I sort the colorMap based on the relative distance between the colors is so I can get it to approximately match the order that the schemes colorapi provides are ordered in, meaning the text and the main colors should always contrast each other rather nicely. This does cause all the schemes to have a dark background with a light text so I might allow the users to change the mode colorapi generates the schemes or change the way I order them (use saturation, lumination, or some other value).
 