### PR TITLE
feat: Add TooltipWrapper to icon buttons

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -19,6 +19,7 @@ import AuthorsDiv from "./AuthorsDiv";
 import TagsDiv from "./TagsDiv";
 import Button from "../Button";
 import { t } from "i18next";
+const Spicetify = window.Spicetify;
 
 export type CardProps = {
   // From `fetchExtensionManifest()`, `fetchThemeManifest()`, and snippets.json
@@ -499,22 +500,28 @@ class Card extends React.Component<CardProps, {
                 ✓ {t("grid.installed")}
               </div>
             )}
-            <div className="main-card-PlayButtonContainer">
-              <Button classes={["marketplace-installButton"]}
-                type="circle"
-                // If it is installed, it will remove it when button is clicked, if not it will save
-                // TODO: Refactor this using lookups or sth similar
-                label={this.props.type === "app" ? t("github") : IS_INSTALLED ? t("remove") : t("install")}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  this.buttonClicked();
-                }}
-              >
-                {/*If the extension, theme, or snippet is already installed, it will display trash, otherwise it displays download*/}
-                {/* TODO: Refactor this using lookups or sth similar */}
-                {this.props.type === "app" ? <GitHubIcon /> : IS_INSTALLED ? <TrashIcon /> : <DownloadIcon />}
-              </Button>
-            </div>
+            <Spicetify.ReactComponent.TooltipWrapper
+              label={this.props.type === "app" ? t("github") : IS_INSTALLED ? t("remove") : t("install")}
+              showDelay={100}
+              renderInline={true}
+            >
+              <div className="main-card-PlayButtonContainer">
+                <Button classes={["marketplace-installButton"]}
+                  type="circle"
+                  // If it is installed, it will remove it when button is clicked, if not it will save
+                  // TODO: Refactor this using lookups or sth similar
+                  label={this.props.type === "app" ? t("github") : IS_INSTALLED ? t("remove") : t("install")}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    this.buttonClicked();
+                  }}
+                >
+                  {/*If the extension, theme, or snippet is already installed, it will display trash, otherwise it displays download*/}
+                  {/* TODO: Refactor this using lookups or sth similar */}
+                  {this.props.type === "app" ? <GitHubIcon /> : IS_INSTALLED ? <TrashIcon /> : <DownloadIcon />}
+                </Button>
+              </div>
+            </Spicetify.ReactComponent.TooltipWrapper>
           </div>
         </div>
       </div>

--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { withTranslation } from "react-i18next";
 import semver from "semver";
 import { Option } from "react-dropdown";
+const Spicetify = window.Spicetify;
 
 import { CardItem, CardType, Config, SchemeIni, Snippet, TabItemConfig } from "../types/marketplace-types";
 import { getLocalStorageDataFromKey, generateSchemesOptions, injectColourScheme, generateKey } from "../logic/Utils";
@@ -519,8 +520,12 @@ class Grid extends React.Component<
           <div className="marketplace-header__right">
             {/* Show theme developer tools button if themeDevTools is enabled */}
             {this.CONFIG.visual.themeDevTools
-              ? <button type="button" title={t("devTools.title")} className="marketplace-header-icon-button"
-                onClick={() => openModal("THEME_DEV_TOOLS")}><ThemeDeveloperToolsIcon/></button>
+              ? <Spicetify.ReactComponent.TooltipWrapper label={t("devTools.title")} renderInline={true} placement="bottom">
+                <button type="button" aria-label={t("devTools.title")} className="marketplace-header-icon-button"
+                  onClick={() => openModal("THEME_DEV_TOOLS")}>
+                  <ThemeDeveloperToolsIcon/>
+                </button>
+              </Spicetify.ReactComponent.TooltipWrapper>
               : null}
             {/* Show colour scheme dropdown if there is a theme with schemes installed */}
             {this.state.activeScheme ? <SortBox
@@ -541,11 +546,13 @@ class Grid extends React.Component<
                 }}
                 onKeyDown={this.handleSearch.bind(this)} />
             </div>
-            <button type="button" title={t("settings.title")} className="marketplace-header-icon-button" id="marketplace-settings-button"
-              onClick={() => openModal("SETTINGS", this.CONFIG, this.updateAppConfig)}
-            >
-              <SettingsIcon />
-            </button>
+            <Spicetify.ReactComponent.TooltipWrapper label={t("settings.title")} renderInline={true} placement="bottom">
+              <button type="button" aria-label={t("settings.title")} className="marketplace-header-icon-button" id="marketplace-settings-button"
+                onClick={() => openModal("SETTINGS", this.CONFIG, this.updateAppConfig)}
+              >
+                <SettingsIcon />
+              </button>
+            </Spicetify.ReactComponent.TooltipWrapper>
           </div>
         </div>
         {/* Add a header and grid for each card type if it has any cards */}


### PR DESCRIPTION
This adds the tooltipwrapper to the theme dev tools and settings buttons. For some reason when I tried to add it to the buttons on the cards, the tooltip doesn't show up. 