### PR TITLE
fix(card): make card button tooltip delay consistent with others

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -498,7 +498,6 @@ class Card extends React.Component<CardProps, {
             )}
             <Spicetify.ReactComponent.TooltipWrapper
               label={this.props.type === "app" ? t("github") : IS_INSTALLED ? t("remove") : t("install")}
-              showDelay={100}
               renderInline={true}
             >
               <div className="main-card-PlayButtonContainer">


### PR DESCRIPTION
The icons in the header (themeDevTools, settings) don't specify a delay, so use the default. This is the only other spot where `TooltipWrapper` is used, other than the tooltips on the dynamic colour scheme question marks, which make sense to have as instant. 