### PR TITLE
fix: fix broken snippet card title links

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -38,7 +38,7 @@ export const CUSTOM_APP_PATH = "/marketplace";
 export const MAX_TAGS = 4;
 
 export const SNIPPETS_PAGE_URL =
-	"https://github.com/spicetify/spicetify-marketplace/blob/main/packages/marketplace/src/resources/snippets.ts";
+	"https://github.com/spicetify/spicetify-marketplace/blob/main/src/resources/snippets.ts";
 
 export const BLACKLIST_URL =
 	"https://raw.githubusercontent.com/spicetify/spicetify-marketplace/main/resources/blacklist.json";


### PR DESCRIPTION
It was going to the old workspaces url before, resulting in a 404