### PR TITLE
feat: add `category` param to `Marketplace.reset()`

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -123,7 +123,7 @@ class Card extends React.Component<CardProps, {
       }
       openModal("RELOAD");
     } else if (this.props.type === "theme") {
-      const themeKey = localStorage.getItem("marketplace:theme-installed");
+      const themeKey = localStorage.getItem(LOCALSTORAGE_KEYS.themeInstalled);
       const previousTheme = themeKey ? getLocalStorageDataFromKey(themeKey, {}) : {};
 
       if (this.isInstalled()) {

--- a/src/logic/Utils.ts
+++ b/src/logic/Utils.ts
@@ -190,7 +190,7 @@ export const generateSchemesOptions = (schemes: SchemeIni) => {
  * Reset Marketplace localStorage keys
  * @param categories The categories to reset. If none provided, reset everything.
  */
-export const resetMarketplace = (...categories: ("extensions" | "snippets" | "theme" | "all")[]) => {
+export const resetMarketplace = (...categories: ("extensions" | "snippets" | "theme")[]) => {
   console.debug("Resetting Marketplace");
 
   const keysToRemove: string[] = [];

--- a/src/logic/Utils.ts
+++ b/src/logic/Utils.ts
@@ -186,16 +186,41 @@ export const generateSchemesOptions = (schemes: SchemeIni) => {
   ));
 };
 
-// Reset any Marketplace localStorage keys (effectively resetting it completely)
-export const resetMarketplace = () => {
+/**
+ * Reset Marketplace localStorage keys
+ * @param category The category to reset. If not provided, reset all categories.
+ */
+export const resetMarketplace = (category: "extensions" | "snippets" | "theme" | "all" = "all") => {
   console.debug("Resetting Marketplace");
 
-  // Loop through and reset marketplace keys
-  Object.keys(localStorage).forEach((key) => {
-    if (key.startsWith("marketplace:")) {
-      localStorage.removeItem(key);
-      console.debug(`Removed ${key}`);
-    }
+  const keysToRemove: string[] = [];
+
+  // If have category, just reset that category
+  if (category === "extensions") {
+    // Remove the extensions themselves
+    keysToRemove.push(...getLocalStorageDataFromKey(LOCALSTORAGE_KEYS.installedExtensions, []));
+    // Remove the list of extension keys
+    keysToRemove.push(LOCALSTORAGE_KEYS.installedExtensions);
+  } else if (category === "snippets") {
+    keysToRemove.push(...getLocalStorageDataFromKey(LOCALSTORAGE_KEYS.installedSnippets, []));
+    keysToRemove.push(LOCALSTORAGE_KEYS.installedSnippets);
+  } else if (category === "theme") {
+    keysToRemove.push(...getLocalStorageDataFromKey(LOCALSTORAGE_KEYS.installedThemes, []));
+    keysToRemove.push(LOCALSTORAGE_KEYS.installedThemes);
+    keysToRemove.push(LOCALSTORAGE_KEYS.themeInstalled);
+  } else {
+    // Loop through all marketplace keys
+    Object.keys(localStorage).forEach((key) => {
+      if (key.startsWith("marketplace:")) {
+        keysToRemove.push(key);
+      }
+    });
+  }
+
+  console.debug(`Removing ${category} from Marketplace (${keysToRemove.length} keys)`);
+  keysToRemove.forEach((key) => {
+    localStorage.removeItem(key);
+    console.debug(`Removed ${key}`);
   });
 
   console.debug("Marketplace has been reset");

--- a/src/logic/Utils.ts
+++ b/src/logic/Utils.ts
@@ -188,28 +188,17 @@ export const generateSchemesOptions = (schemes: SchemeIni) => {
 
 /**
  * Reset Marketplace localStorage keys
- * @param category The category to reset. If not provided, reset all categories.
+ * @param categories The categories to reset. If none provided, reset everything.
  */
-export const resetMarketplace = (category: "extensions" | "snippets" | "theme" | "all" = "all") => {
+export const resetMarketplace = (...categories: ("extensions" | "snippets" | "theme" | "all")[]) => {
   console.debug("Resetting Marketplace");
 
   const keysToRemove: string[] = [];
 
-  // If have category, just reset that category
-  if (category === "extensions") {
-    // Remove the extensions themselves
-    keysToRemove.push(...getLocalStorageDataFromKey(LOCALSTORAGE_KEYS.installedExtensions, []));
-    // Remove the list of extension keys
-    keysToRemove.push(LOCALSTORAGE_KEYS.installedExtensions);
-  } else if (category === "snippets") {
-    keysToRemove.push(...getLocalStorageDataFromKey(LOCALSTORAGE_KEYS.installedSnippets, []));
-    keysToRemove.push(LOCALSTORAGE_KEYS.installedSnippets);
-  } else if (category === "theme") {
-    keysToRemove.push(...getLocalStorageDataFromKey(LOCALSTORAGE_KEYS.installedThemes, []));
-    keysToRemove.push(LOCALSTORAGE_KEYS.installedThemes);
-    keysToRemove.push(LOCALSTORAGE_KEYS.themeInstalled);
-  } else {
-    // Loop through all marketplace keys
+  // If no categories provided, reset everything
+  if (categories.length === 0) {
+    // Loop through all marketplace keys.
+    // This includes extensions, themes, and snippets, as well as the Marketplace settings.
     Object.keys(localStorage).forEach((key) => {
       if (key.startsWith("marketplace:")) {
         keysToRemove.push(key);
@@ -217,7 +206,23 @@ export const resetMarketplace = (category: "extensions" | "snippets" | "theme" |
     });
   }
 
-  console.debug(`Removing ${category} from Marketplace (${keysToRemove.length} keys)`);
+  // If have categories, reset only those
+  categories.forEach((category) => {
+    if (category === "extensions") {
+      // Remove the extensions themselves
+      keysToRemove.push(...getLocalStorageDataFromKey(LOCALSTORAGE_KEYS.installedExtensions, []));
+      // Remove the list of extension keys
+      keysToRemove.push(LOCALSTORAGE_KEYS.installedExtensions);
+    } else if (category === "snippets") {
+      keysToRemove.push(...getLocalStorageDataFromKey(LOCALSTORAGE_KEYS.installedSnippets, []));
+      keysToRemove.push(LOCALSTORAGE_KEYS.installedSnippets);
+    } else if (category === "theme") {
+      keysToRemove.push(...getLocalStorageDataFromKey(LOCALSTORAGE_KEYS.installedThemes, []));
+      keysToRemove.push(LOCALSTORAGE_KEYS.installedThemes);
+      keysToRemove.push(LOCALSTORAGE_KEYS.themeInstalled);
+    }
+  });
+
   keysToRemove.forEach((key) => {
     localStorage.removeItem(key);
     console.debug(`Removed ${key}`);


### PR DESCRIPTION
This allows you to specify a category of item to reset. It still reloads the window after the operation has completed. I wasn't sure which param format would be best, so I just went with simple one operation per call for now. 

Current usage: 
```js
Marketplace.reset();
Marketplace.reset('extensions');
```

Other potential options we might consider:
```js
Marketplace.reset({
  snippets: true,
});
Marketplace.reset(['theme']);
```

EDIT: We went with a rest param, like so:
```js
// Reset individual items
Marketplace.reset('theme');
Marketplace.reset('theme', 'snippets');
// Reset everything (including settings)
Marketplace.reset();
```