### PR TITLE
fix(readme): set img relative to readme

### DIFF
--- a/src/components/ReadmePage.tsx
+++ b/src/components/ReadmePage.tsx
@@ -87,7 +87,9 @@ class ReadmePage extends React.Component<
       img.addEventListener("error", (e) => {
         const element = e.target as HTMLImageElement;
         const originalSrc = element.getAttribute("src");
-        const fixedSrc = `${this.props.data.readmeURL.substring(0, this.props.data.readmeURL.lastIndexOf("/"))}/${originalSrc}`;
+        const fixedSrc = originalSrc?.charAt(0) === "/"
+          ? `https://raw.githubusercontent.com/${this.props.data.user}/${this.props.data.repo}/${this.props.data.branch}/${originalSrc?.slice(1)}`
+          : `${this.props.data.readmeURL.substring(0, this.props.data.readmeURL.lastIndexOf("/"))}/${originalSrc}`;
         element.setAttribute("src", fixedSrc);
       }, { once: true });
     });

--- a/src/components/ReadmePage.tsx
+++ b/src/components/ReadmePage.tsx
@@ -82,12 +82,12 @@ class ReadmePage extends React.Component<
     // Add error handler in attempt to fix broken image urls
     // e.g. "screenshot.png" loads https://xpui.app.spotify.com/screenshot.png and breaks
     // so I turn it into https://raw.githubusercontent.com/theRealPadster/spicetify-hide-podcasts/main/screenshot.png
-    // This works for urls relative to the repo root
+    // This works for urls relative to the repo readme
     document.querySelectorAll("#marketplace-readme img").forEach((img) => {
       img.addEventListener("error", (e) => {
         const element = e.target as HTMLImageElement;
         const originalSrc = element.getAttribute("src");
-        const fixedSrc = `https://raw.githubusercontent.com/${this.props.data.user}/${this.props.data.repo}/${this.props.data.branch}/${originalSrc}`;
+        const fixedSrc = `${this.props.data.readmeURL.substring(0, this.props.data.readmeURL.lastIndexOf("/"))}/${originalSrc}`;
         element.setAttribute("src", fixedSrc);
       }, { once: true });
     });


### PR DESCRIPTION
Fixes the image urls being wrong for all of the themes from the spictify-themes repo. spicetify/spicetify-themes#901