### PR TITLE
feat: add "version" section to bottom of settings modal

### DIFF
--- a/src/components/Modals/Settings/index.tsx
+++ b/src/components/Modals/Settings/index.tsx
@@ -22,10 +22,18 @@ const SettingsModal = ({ CONFIG, updateAppConfig } : Props) => {
   // then when updating anything in the main state, also updates the SettingsModal state
 
   const [modalConfig, setModalConfig] = React.useState({ ...CONFIG });
+  const [versionButtonText, setVersionButtonText] = React.useState(t("settings.versionBtn"));
   // TODO: use React.useCallback?
   const updateConfig = (CONFIG: Config) => {
     updateAppConfig({ ...CONFIG });
     setModalConfig({ ...CONFIG });
+  };
+
+  /** Copy Marketplace version to clipboard and update button text */
+  const copyVersion = () => {
+    Spicetify.Platform.ClipboardAPI.copy(MARKETPLACE_VERSION);
+    setVersionButtonText(t("settings.versionCopied"));
+    setTimeout(() => setVersionButtonText(t("settings.versionBtn")), 3000);
   };
 
   // Can't use proper event listener here because it's just the DOM outside the component
@@ -41,6 +49,7 @@ const SettingsModal = ({ CONFIG, updateAppConfig } : Props) => {
       }
     };
   }
+
   const AlbumArtColorDropDowns = getLocalStorageDataFromKey(LOCALSTORAGE_KEYS.albumArtBasedColor) ? <>
     <ConfigRow name={t("settings.albumArtBasedColorsMode")} storageKey='albumArtBasedColorsMode' modalConfig={modalConfig} updateConfig={updateConfig} type="dropdown" options={["monochromeDark", "monochromeLight", "analogicComplement", "analogic", "triad", "quad"]} description={t("settings.almbumArtColorsModeToolTip")} />
     <ConfigRow name={t("settings.albumArtBasedColorsVibrancy")} storageKey='albumArtBasedColorsVibrancy' modalConfig={modalConfig} updateConfig={updateConfig} type="dropdown" options={["desaturated", "lightVibrant", "prominent", "vibrant"]} description={t("settings.albumArtBasedColorsVibrancyToolTip")} /></> : null;
@@ -81,17 +90,11 @@ const SettingsModal = ({ CONFIG, updateAppConfig } : Props) => {
           {t("grid.spicetifyMarketplace")} {MARKETPLACE_VERSION}
         </label>
         <div className="col action">
-          <Button onClick={copyVersion}>{t("settings.versionBtn")}</Button>
+          <Button onClick={copyVersion}>{versionButtonText}</Button>
         </div>
       </div>
     </div>
   );
-};
-
-const copyVersion = () => {
-  Spicetify.Platform.ClipboardAPI.copy(MARKETPLACE_VERSION);
-  // TODO: It looks like the notification is underneath the modal, so is not visible
-  Spicetify.showNotification(t("settings.versionCopied"));
 };
 
 const onBackupClick = async () => {

--- a/src/components/Modals/Settings/index.tsx
+++ b/src/components/Modals/Settings/index.tsx
@@ -9,7 +9,7 @@ import Button from "../../Button";
 import TabRow from "./TabRow";
 
 import { openModal } from "../../../logic/LaunchModals";
-import { LOCALSTORAGE_KEYS } from "../../../constants";
+import { LOCALSTORAGE_KEYS, MARKETPLACE_VERSION } from "../../../constants";
 
 interface Props {
   CONFIG: Config;
@@ -75,8 +75,23 @@ const SettingsModal = ({ CONFIG, updateAppConfig } : Props) => {
           <Button onClick={onBackupClick}>{t("settings.backupBtn")}</Button>
         </div>
       </div>
+      <h2>{t("settings.versionHeading")}</h2>
+      <div className="setting-row">
+        <label className="col description">
+          {t("grid.spicetifyMarketplace")} {MARKETPLACE_VERSION}
+        </label>
+        <div className="col action">
+          <Button onClick={copyVersion}>{t("settings.versionBtn")}</Button>
+        </div>
+      </div>
     </div>
   );
+};
+
+const copyVersion = () => {
+  Spicetify.Platform.ClipboardAPI.copy(MARKETPLACE_VERSION);
+  // TODO: It looks like the notification is underneath the modal, so is not visible
+  Spicetify.showNotification(t("settings.versionCopied"));
 };
 
 const onBackupClick = async () => {

--- a/src/resources/locales/en.json
+++ b/src/resources/locales/en.json
@@ -22,7 +22,7 @@
       "backupBtn": "Open",
       "versionHeading": "Version",
       "versionBtn": "Copy",
-      "versionCopied": "Version copied to clipboard"
+      "versionCopied": "Copied"
     },
     "tabs": {
       "Extensions": "Extensions",

--- a/src/resources/locales/en.json
+++ b/src/resources/locales/en.json
@@ -19,7 +19,10 @@
       "resetDescription": "Uninstall all extensions and themes, and reset preferences",
       "backupHeading": "Back up/Restore",
       "backupLabel": "Back up or restore all Marketplace data. This does not include settings for anything installed via Marketplace.",
-      "backupBtn": "Open"
+      "backupBtn": "Open",
+      "versionHeading": "Version",
+      "versionBtn": "Copy",
+      "versionCopied": "Version copied to clipboard"
     },
     "tabs": {
       "Extensions": "Extensions",


### PR DESCRIPTION
Adds "version" section to the bottom of settings modal. 
Also adds a few new language strings. 

I'm not sure if this UI is inherently better than just putting "v0.8.5" in the bottom corner somewhere and copying on click or something. Feel free to chime in. 

It would also be nice if we could integrate the update checker here and show a button if there's a new version. 

<img width="699" alt="image" src="https://user-images.githubusercontent.com/1565883/227807563-bc2177f5-65e5-4fc1-9f0c-6a3053d2158a.png">

