### PR TITLE
fix(tab-bar): resize on initial run

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "spicetify-marketplace",
-	"version": "0.8.5",
+	"version": "0.8.6",
 	"homepage": "https://github.com/spicetify/spicetify-marketplace",
 	"repository": {
 		"type": "git",

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -96,12 +96,11 @@ export const TopBarContent = (props: {
     return () => {
       observer.disconnect();
     };
-  }, [resizeHandler]);
+  });
   useEffect(()=>{
     contextHandler();
   });
   return (
-
     <TabBar
       windowSize={windowSize}
       links={props.links}
@@ -134,7 +133,7 @@ const TabBar = React.memo<TabBarProps>(
     useEffect(() => {
       if (!tabBarRef.current) return;
       setAvailableSpace(tabBarRef.current.clientWidth);
-    }, [windowSize]);
+    }, [windowSize, tabBarRef.current?.clientWidth]);
 
     useEffect(() => {
       if (!tabBarRef.current) return;


### PR DESCRIPTION
Resolves #469 
Also bumps version for next release.
![Spotify_kCO8V3FJch](https://github.com/spicetify/spicetify-marketplace/assets/77577746/15940c06-0453-44f3-b8fd-1a88058b2209)
