### PR TITLE
fix(install): get userdata path without spicetify call

### DIFF
--- a/resources/install.ps1
+++ b/resources/install.ps1
@@ -12,12 +12,7 @@ if (-not (Get-Command -Name spicetify -ErrorAction SilentlyContinue)) {
   Invoke-WebRequest @Parameters | Invoke-Expression
 }
 
-spicetify path userdata | Out-Null
-$spiceUserDataPath = spicetify path userdata
-if ($LASTEXITCODE) {
-  Write-Host -Object "Something is wrong with your Spicetify installation. Check the message below." -ForegroundColor Red
-  throw $spiceUserDataPath
-}
+$spiceUserDataPath = "$env:APPDATA\spicetify"
 $marketAppPath = "$spiceUserDataPath\CustomApps\marketplace"
 $marketThemePath = "$spiceUserDataPath\Themes\marketplace"
 $isThemeInstalled = $(


### PR DESCRIPTION
`spicetify path userdata` output is too unreliable