### PR TITLE
fix(extensions): jsdelivr use xyz domain name

### DIFF
--- a/src/extensions/extension.tsx
+++ b/src/extensions/extension.tsx
@@ -64,7 +64,7 @@ import {
     if (isGithubRawUrl(script.src)) {
       const { user, repo, branch, filePath } = getParamsFromGithubRaw(extensionManifest.extensionURL);
       if (!user || !repo || !branch || !filePath) return;
-      script.src = `https://cdn.jsdelivr.net/gh/${user}/${repo}@${branch}/${filePath}`;
+      script.src = `https://cdn.jsdelivr.xyz/gh/${user}/${repo}@${branch}/${filePath}`;
     }
 
     script.src = `${script.src}?time=${Date.now()}`;
@@ -128,7 +128,7 @@ import {
         // If it's a github raw script, use jsdelivr
         if (isGithubRawUrl(script)) {
           const { user, repo, branch, filePath } = getParamsFromGithubRaw(script);
-          src = `https://cdn.jsdelivr.net/gh/${user}/${repo}@${branch}/${filePath}`;
+          src = `https://cdn.jsdelivr.xyz/gh/${user}/${repo}@${branch}/${filePath}`;
         }
         // console.log({src});
         newScript.src = `${src}?time=${Date.now()}`;

--- a/src/logic/Utils.ts
+++ b/src/logic/Utils.ts
@@ -422,7 +422,7 @@ export const parseCSS = async (themeData: CardItem) => {
 
   const userCssUrl = isGithubRawUrl(themeData.cssURL)
   // TODO: this should probably be the URL stored in localstorage actually (i.e. put this url in localstorage)
-    ? `https://cdn.jsdelivr.net/gh/${themeData.user}/${themeData.repo}@${themeData.branch}/${themeData.manifest.usercss}`
+    ? `https://cdn.jsdelivr.xyz/gh/${themeData.user}/${themeData.repo}@${themeData.branch}/${themeData.manifest.usercss}`
     : themeData.cssURL;
   // TODO: Make this more versatile
   const assetsUrl = userCssUrl.replace("/user.css", "/assets/");

--- a/src/styles/components/_readme-pages.scss
+++ b/src/styles/components/_readme-pages.scss
@@ -6,7 +6,7 @@
 // TODO: I wanted to get it to just @import the external URL and customize the colours,
 // but I'm not sure how to get that working yet
 // See here? https://www.npmjs.com/package/postcss-import-url
-// @import url(https://cdn.jsdelivr.net/npm/water.css@2/out/water.css);
+// @import url(https://cdn.jsdelivr.xyz/npm/water.css@2/out/water.css);
 
 // (This is just for reference)
 .spicetify-root-vars {


### PR DESCRIPTION
The use of .xyz instead of .net bypasses blocks in Egypt and China, it seems these countries only block the most popular domain.
This does not affect users outside of these countries, i have verified this serves its intended purpose.