### PR TITLE
fix(snippets): circular album art

### DIFF
--- a/src/resources/snippets.ts
+++ b/src/resources/snippets.ts
@@ -98,7 +98,7 @@ export default [
   {
     "title": "Circular Album Art",
     "description": "Makes the now playing album art be circular (like a vinyl)",
-    "code": ".cover-art .cover-art-image {\n    border-radius: 100% !important;\n}",
+    "code": ".cover-art { clip-path: circle(50% at 50% 50%);}",
     "preview": "resources/assets/snippets/circular-album-art.png",
   },
   {


### PR DESCRIPTION
Updated the CSS code for the circular album art snippet I wrote last year (the one that does not rotate). Edited snippets.ts with the updated code.

Here's the segment with the new code for the existing snippet:
{
    "title": "Circular Album Art",
    "description": "Makes the now playing album art be circular (like a vinyl) without image rotation",
    "code": ".cover-art { clip-path: circle(50% at 50% 50%);}",
    "preview": "resources/assets/snippets/circular-album-art.png",
  },