### PR TITLE
fix(install): stop running backup quietly

### DIFF
--- a/resources/install.ps1
+++ b/resources/install.ps1
@@ -54,7 +54,7 @@ Write-Host -Object 'Applying...' -ForegroundColor Cyan
 if (-not $isThemeInstalled) {
   spicetify config current_theme marketplace
 }
-spicetify backup -q
+spicetify backup
 spicetify apply
 
 Write-Host -Object 'Done!' -ForegroundColor Green


### PR DESCRIPTION
When backup is run in quiet mode, user doesn't know why the command exited with error code because it doesn't show any error message