### PR TITLE
feat(install/windows): use provided userdata path

### DIFF
--- a/resources/install.ps1
+++ b/resources/install.ps1
@@ -12,7 +12,11 @@ if (-not (Get-Command -Name spicetify -ErrorAction SilentlyContinue)) {
   Invoke-WebRequest @Parameters | Invoke-Expression
 }
 
-$spiceUserDataPath = "$env:APPDATA\spicetify"
+spicetify path userdata | Out-Null
+$spiceUserDataPath = (spicetify path userdata)
+if (-not (Test-Path -Path $spiceUserDataPath -PathType Container)) {
+  $spiceUserDataPath = "$env:APPDATA\spicetify"
+}
 $marketAppPath = "$spiceUserDataPath\CustomApps\marketplace"
 $marketThemePath = "$spiceUserDataPath\Themes\marketplace"
 $isThemeInstalled = $(


### PR DESCRIPTION
brings support for scoop/winget/etc spicetify installations, but will still work if spicetify returns error/warning with/without path - no cons