### PR TITLE
fix(styles/grid): remove `option` background recolor

### DIFF
--- a/src/styles/components/_grid.scss
+++ b/src/styles/components/_grid.scss
@@ -140,10 +140,6 @@
   color: var(--spice-text) !important;
 }
 
-option {
-  background-color: var(--spice-button);
-}
-
 .marketplace-footer {
   margin: auto;
   text-align: center;


### PR DESCRIPTION
before:

![image](https://github.com/spicetify/spicetify-marketplace/assets/115353812/832fa26c-a2e5-4a12-88c3-376c5eae8d6b)

after:

![image](https://github.com/spicetify/spicetify-marketplace/assets/115353812/0874105f-8896-4fac-b94f-8bec35a7b328)

no theme