### PR TITLE
fix(snippets): update `Smaller right sidebar covert art` classes

### DIFF
--- a/src/resources/snippets.ts
+++ b/src/resources/snippets.ts
@@ -332,7 +332,7 @@ export default [
   {
     "title": "Smaller right sidebar covert art",
     "description": "Makes the right sidebar cover art smaller and move the track info to the right",
-    "code": ":root { --right-sidebar-cover-art-size: 85px; } \n.main-nowPlayingView-coverArt { width: var(--right-sidebar-cover-art-size); } \n.zL6hQR4mukVUUQaa_7K1 { min-height: unset !important; height: var(--right-sidebar-cover-art-size) !important; } \n.main-nowPlayingView-nowPlayingGrid { flex-direction: unset; } \n.main-nowPlayingView-contextItemInfo .main-trackInfo-name { font-size: 1.25rem; } \n.main-nowPlayingView-contextItemInfo .main-trackInfo-artists { font-size: 0.85rem; }",
+    "code": ":root { --right-sidebar-cover-art-size: 85px; } \n.main-nowPlayingView-coverArt { width: var(--right-sidebar-cover-art-size); } \n.main-nowPlayingView-coverArtContainer { min-height: unset !important; height: var(--right-sidebar-cover-art-size) !important; } \n.main-nowPlayingView-nowPlayingGrid { flex-direction: unset; } \n.main-nowPlayingView-contextItemInfo .main-trackInfo-name { font-size: 1.25rem; } \n.main-nowPlayingView-contextItemInfo .main-trackInfo-artists { font-size: 0.85rem; }",
     "preview": "resources/assets/snippets/smaller-right-sidebar-cover.png",
   },
 ];


### PR DESCRIPTION
this class was mapped in the spicetify/spicetify-cli#2665