### PR TITLE
fix(grid): update check with spotify v1.2.26 & update modal

### DIFF
--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -464,7 +464,7 @@ class Grid extends React.Component<
         });
 
         try {
-          this.setState({ newUpdate: semver.gt(this.state.version, MARKETPLACE_VERSION) });
+          this.setState({ newUpdate: semver.gt(result.name, MARKETPLACE_VERSION) });
         } catch (err) {
           console.error(err);
         }

--- a/src/components/Modals/Update/index.tsx
+++ b/src/components/Modals/Update/index.tsx
@@ -20,7 +20,7 @@ async function fetchLatestReleaseInfo(): Promise<{
       ? {
         version: tag_name.replace("v", ""),
         changelog: await getMarkdownHTML(
-          body.match(/## What's Changed\n([\s\S]*?)\n\n##/)[1],
+          body.match(/## What's Changed([\s\S]*?)(\r\n\r|\n\n##)/)[1],
           "spicetify",
           "spicetify-marketplace",
         ),

--- a/src/components/Modals/Update/index.tsx
+++ b/src/components/Modals/Update/index.tsx
@@ -20,7 +20,7 @@ async function fetchLatestReleaseInfo(): Promise<{
       ? {
         version: tag_name.replace("v", ""),
         changelog: await getMarkdownHTML(
-          body.match(/## What's Changed([\s\S]*?)\r\n\r/)[1],
+          body.match(/## What's Changed\n([\s\S]*?)\n\n##/)[1],
           "spicetify",
           "spicetify-marketplace",
         ),


### PR DESCRIPTION
react has been updated to version 18.0.2 in spotify v1.2.26, so this code no longer works because of the [automatic batching](https://blog.appsignal.com/2022/04/13/whats-new-in-react-18.html#:~:text=Automatic%20Batching%20in%20React%2018)

![image](https://github.com/spicetify/spicetify-marketplace/assets/115353812/a491023c-f48f-4fa1-adc3-13b5e09c1d92)
