### PR TITLE
fix(components/TagsDiv): move tags to extra if their number exceeds max by 1+

### DIFF
--- a/src/components/Card/TagsDiv.tsx
+++ b/src/components/Card/TagsDiv.tsx
@@ -40,14 +40,14 @@ const TagsDiv = (props: {
       return accum;
     }, []);
   };
-
-  const baseTags = props.tags
-    // Sort tags so that externalJS and archived tags come first
-    .sort((a) =>
-      a === t("grid.externalJS") || a === t("grid.archived") ? -1 : 1,
-    )
-    .slice(0, MAX_TAGS);
-  const extraTags = props.tags.slice(MAX_TAGS);
+  // Sort tags so that externalJS and archived tags come first
+  let baseTags = props.tags.sort((a) => a === t("grid.externalJS") || a === t("grid.archived") ? -1 : 1);
+  let extraTags: string[] = [];
+  // If there are more than one extra tags, slice them and add an expand button
+  if (baseTags.length - MAX_TAGS > 1) {
+    extraTags = props.tags.slice(MAX_TAGS);
+    baseTags = baseTags.slice(0, MAX_TAGS);
+  }
 
   // Render the tags list and add expand button if there are more tags
   return (


### PR DESCRIPTION
idk how to make the name shorter

before:

![Spotify_LQsvzdj0pu](https://github.com/spicetify/spicetify-marketplace/assets/115353812/afd65c68-7b9a-4cf8-85d6-972c170f17c6)

after:

![image](https://github.com/spicetify/spicetify-marketplace/assets/115353812/025fa2c8-dc52-4fed-accf-55d0af1381eb)
