### PR TITLE
feat: add `spiceDL` to the blacklist

### DIFF
--- a/resources/blacklist.json
+++ b/resources/blacklist.json
@@ -1,5 +1,3 @@
 {
-  "repos": [
-    
-  ]
+	"repos": ["https://github.com/FoxRefire/spiceDL"]
 }


### PR DESCRIPTION
This extension has alternative backend (`zotify`) that downloads music and podcasts off the spotify servers. This is a piracy. I don't mind the `spotdl` backend because it uses ytdl to download music, but the alt one is too much. I'm not going to risk anything just because of this extension