### PR TITLE
feat: add extension to the blacklist

### DIFF
--- a/resources/blacklist.json
+++ b/resources/blacklist.json
@@ -1,3 +1,6 @@
 {
-	"repos": ["https://github.com/FoxRefire/spiceDL"]
+	"repos": [
+		"https://github.com/FoxRefire/spiceDL",
+		"https://github.com/dupitydumb/LyricsPlus-Spotify"
+	]
 }


### PR DESCRIPTION
This extension uses `LyricsPlus` name and such is confusing to our users because they're greeted with modified Lyrics-Plus with some gradient background that cannot be disabled.
If the author will change the name, we can remove it from the blacklist